### PR TITLE
Add audio support for Core Desktop

### DIFF
--- a/scripts/run-session.sh
+++ b/scripts/run-session.sh
@@ -8,4 +8,5 @@ chmod 01777 /tmp/.X11-unix
 mkdir -p --mode=700 $XDG_RUNTIME_DIR
 
 export GNOME_SHELL_SESSION_MODE=ubuntu
+export PULSE_SERVER=unix:/run/user/`id -u`/pulse/native
 exec /usr/bin/gnome-session --session=ubuntu

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,6 +26,9 @@ apps:
     slots:
       - wayland
       - x11
+    plugs:
+      - audio-playback
+      - audio-record
 
   gnome-terminal-server:
     command: run.sh /usr/libexec/gnome-terminal-server
@@ -60,6 +63,8 @@ apps:
         - dbus-freedesktop-impl-portal-gtk
 
 plugs:
+  audio-playback: null
+  audio-record: null
   desktop-launch: null
   hardware-observe: null
   home: null


### PR DESCRIPTION
This is one of the three MRs required for adding audio support to Core Desktop. This one adds the required plugs to the session and defines the PULSE_SERVER environment variable to make it point to the right path.