### PR TITLE
scripts: force builtin session management

### DIFF
--- a/scripts/run-session.sh
+++ b/scripts/run-session.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-# Ensure socket directory exists and has the right permissions
-mkdir -p /tmp/.X11-unix
-chmod 01777 /tmp/.X11-unix
+# Ensure socket directories exist and have the right permissions
+mkdir -p /tmp/.X11-unix /tmp/.ICE-unix
+chmod 01777 /tmp/.X11-unix /tmp/.ICE-unix
 
 # Create the runtime directory
 mkdir -p --mode=700 $XDG_RUNTIME_DIR

--- a/scripts/run-session.sh
+++ b/scripts/run-session.sh
@@ -8,4 +8,4 @@ chmod 01777 /tmp/.X11-unix /tmp/.ICE-unix
 mkdir -p --mode=700 $XDG_RUNTIME_DIR
 
 export GNOME_SHELL_SESSION_MODE=ubuntu
-exec /usr/bin/gnome-session --session=ubuntu
+exec /usr/bin/gnome-session --builtin --session=ubuntu


### PR DESCRIPTION
gnome-session can run in two different modes: 
 * systemd mode, where it asks systemd to start various components as separate units
 * built-in session management, where it starts those components itself

We are using built-in mode, as the confined session doesn't have permission to talk to systemd itself. But it does this as a fallback.

If the snap is put into devmode or its AppArmor profiles reloaded in complain mode, it'll switch to systemd mode and a bunch of components will be loaded without any snap confinement. By passing `--builtin` to gnome-session, we can force it to use built-in mode in this case.