### PR TITLE
snap: update architectures stanza to explicitly build on amd64, taretting all

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,7 +18,8 @@ description: |
 grade: devel
 confinement: strict
 architectures:
-  - all
+  - build-on: amd64
+    run-on: all
 
 apps:
   ubuntu-desktop-session:


### PR DESCRIPTION
This is essentially the same problem we had in gtk-common-themes here:

https://gitlab.gnome.org/Community/Ubuntu/gtk-common-themes/-/merge_requests/30