### PR TITLE
Add audio slots

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,7 +55,6 @@ apps:
     passthrough:
       daemon-scope: user
     plugs:
-      - snapd-control
       - alsa
 
   wireplumber:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -101,8 +101,6 @@ apps:
         - dbus-freedesktop-impl-portal-gtk
 
 plugs:
-  audio-playback: null
-  audio-record: null
   desktop-launch: null
   hardware-observe: null
   home: null
@@ -132,7 +130,10 @@ plugs:
   upower-observe: null
 
 slots:
-  desktop:
+  audio-playback: null
+  audio-record: null
+  pulseaudio: null
+  desktop: null
   dbus-canonical-unity:
     interface: dbus
     bus: session


### PR DESCRIPTION
This contains a few changes following up on #6.

1. we're already had push back against adding a snapd-control plug, so remove it for now. This breaks the current pipewire snap detection code, but we can make it work via the snapctl API. Frustratingly, there isn't a single API that will work for both the snapped and unsnapped cases, but I think we can have a single binary that holds both code paths.
2. convert the `audio-{playback,record}` plugs to slots, so other snaps can connect to them. Also add a `pulseaudio` slot to support legacy snaps still using it.