### PR TITLE
Added bluez and bluetooth-control plugs to allow enabling bluetooth via settings

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -100,6 +100,8 @@ apps:
         - dbus-freedesktop-impl-portal-gtk
 
 plugs:
+  bluez: null
+  bluetooth-control: null
   desktop-launch: null
   hardware-observe: null
   home: null


### PR DESCRIPTION
This does allow access to enable/disable bluetooth, however the UI toggle in gnome-control-center doesn't seem to get the event.  But it does actual function with these plugs enabled.