### PR TITLE
Added ssh-keys plug to the session

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -114,6 +114,7 @@ plugs:
   polkit-agent: null
   process-control: null
   shutdown: null
+  ssh-keys: null
   system-observe: null
   shell-config-files:
     interface: system-files


### PR DESCRIPTION
This eases ssh from gnome-terminal.  At some point if we drop gnome-terminal this might not be as useful.