### PR TITLE
Plug cups-control to allow access to manage printing

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -94,6 +94,7 @@ apps:
 plugs:
   bluez: null
   bluetooth-control: null
+  cups-control: null
   desktop-launch: null
   hardware-observe: null
   home: null


### PR DESCRIPTION
Necessary for printer settings in gnome-control-center