### PR TITLE
DBus activation for IBus

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -105,6 +105,30 @@ apps:
       activates-on:
         - dbus-freedesktop-impl-portal-gtk
 
+  ibus-service:
+    command: run.sh /usr/bin/ibus-daemon --panel disable
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+      activates-on:
+        - dbus-ibus
+
+  ibus-gtk3-service:
+    command: run.sh /usr/libexec/ibus-extension-gtk3
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+      activates-on:
+        - dbus-ibus-gtk3
+
+  ibus-portal-service:
+    command: run.sh /usr/libexec/ibus-portal
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+      activates-on:
+        - dbus-ibus-portal
+
 plugs:
   avahi-control: null
   bluez: null
@@ -356,6 +380,18 @@ slots:
   dbus-wireplumber:
     interface: dbus
     name: org.freedesktop.ReserveDevice1
+    bus: session
+  dbus-ibus:
+    interface: dbus
+    name: org.freedesktop.IBus
+    bus: session
+  dbus-ibus-gtk3:
+    interface: dbus
+    name: org.freedesktop.IBus.Panel.Extension.Gtk3
+    bus: session
+  dbus-ibus-portal:
+    interface: dbus
+    name: org.freedesktop.portal.IBus
     bus: session
 
 parts:


### PR DESCRIPTION
This patch adds to the session the required DBus activation for IBus, required to launch it when needed. It requires

https://github.com/canonical/core-base-desktop/pull/19