### PR TITLE
Udeng 912 locale and keyboard are not correctly set 2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -171,9 +171,6 @@ plugs:
   system-observe: null
   shell-session-locale-files:
     interface: personal-files
-    read:
-      - $HOME/.pam_environment
-      - $HOME/.xinputrc
     write:
       - $HOME/.pam_environment
       - $HOME/.xinputrc

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,7 +30,7 @@ apps:
       - time-control
       - timeserver-control
       - timezone-control
-      - dot-config-files
+      - shell-session-locale-files
 
   pipewire:
     command: run.sh /usr/bin/pipewire
@@ -168,7 +168,7 @@ plugs:
   shutdown: null
   ssh-keys: null
   system-observe: null
-  dot-config-files:
+  shell-session-locale-files:
     interface: personal-files
     read:
       - $HOME/.pam_environment

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,6 +27,7 @@ apps:
       - x11
     plugs:
       - account-control
+      - locale-control
       - time-control
       - timeserver-control
       - timezone-control

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,7 @@ apps:
       - time-control
       - timeserver-control
       - timezone-control
+      - dot-config-files
 
   pipewire:
     command: run.sh /usr/bin/pipewire
@@ -167,6 +168,14 @@ plugs:
   shutdown: null
   ssh-keys: null
   system-observe: null
+  dot-config-files:
+    interface: personal-files
+    read:
+      - $HOME/.pam_environment
+      - $HOME/.xinputrc
+    write:
+      - $HOME/.pam_environment
+      - $HOME/.xinputrc
   shell-config-files:
     interface: system-files
     read:
@@ -178,6 +187,9 @@ plugs:
       - /etc/shells
       - /etc/xdg/autostart
       - /run/udev/tags/seat
+      - /etc/default/im-config
+      - /etc/X11/xinit/xinputrc
+      - /etc/default/locale
   upower-observe: null
 
 slots:
@@ -412,6 +424,10 @@ slots:
   dbus-colord:
     interface: dbus
     name: org.freedesktop.ColorHelper
+    bus: session
+  dbus-language-selector:
+    interface: dbus
+    name: com.ubuntu.GnomeLanguageSelector
     bus: session
 
 parts:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -425,10 +425,6 @@ slots:
     interface: dbus
     name: org.freedesktop.ColorHelper
     bus: session
-  dbus-language-selector:
-    interface: dbus
-    name: com.ubuntu.GnomeLanguageSelector
-    bus: session
 
 parts:
   scripts:


### PR DESCRIPTION
This patch adds access to .pam_environment and .xinputrc to allow to set language and keyboard in the core-desktop session.