### PR TITLE
Add restart delay to portal-gtk/gnome

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -98,6 +98,7 @@ apps:
       daemon-scope: user
       activates-on:
         - dbus-freedesktop-impl-portal-gnome
+    restart-delay: 1s
 
   xdg-desktop-portal-gtk:
     command: run.sh /usr/libexec/xdg-desktop-portal-gtk
@@ -106,6 +107,7 @@ apps:
       daemon-scope: user
       activates-on:
         - dbus-freedesktop-impl-portal-gtk
+    restart-delay: 1s
 
   ibus-service:
     command: run.sh /usr/bin/ibus-daemon --panel disable


### PR DESCRIPTION
If xdg-desktop-portal-gtk/gnome fail to launch, it makes no sense to try to relaunch immediately, because the problem can be something that requires a little more time to be fixed (like a missing X pipe).

This patch fixes it by adding a restart delay.