### PR TITLE
Create xdg runtime dir in session wrapper script

### DIFF
--- a/scripts/session-wrapper.sh
+++ b/scripts/session-wrapper.sh
@@ -11,6 +11,8 @@ fi
 export XDG_CURRENT_DESKTOP=ubuntu:GNOME
 export GSETTINGS_BACKEND=keyfile
 
+mkdir -p --mode=700 $XDG_RUNTIME_DIR
+
 dbus-update-activation-environment --systemd --all
 
 # Don't set this in our own environment, since it will make


### PR DESCRIPTION
Currently, the XDG_RUNTIME_DIR is created in the run-session.sh script; but it should be created before, because several elements require it.

This patch creates the folder in the session-wrapper.sh script, which is the first one to be launched.