### PR TITLE
snap: set XDG_STATE_HOME environment variable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,6 +18,7 @@ environment:
   XDG_CACHE_HOME: $SNAP_USER_COMMON/.cache
   XDG_CONFIG_HOME: $SNAP_USER_COMMON/.config
   XDG_DATA_HOME: $SNAP_USER_COMMON/.local/share
+  XDG_STATE_HOME: $SNAP_USER_COMMON/.local/state
 
 apps:
   ubuntu-desktop-session:


### PR DESCRIPTION
This is a new variable introduced in the XDG Base Directory Specification 0.8, and without it some apps will attempt to create and write to ~/.local/state and misbehave since that directory is off limits to the snap.

In particular, wireplumber wants to use this directory now.