### PR TITLE
Drop the GTK portal to unblock gnome-shell startup

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -101,14 +101,14 @@ apps:
         - dbus-freedesktop-impl-portal-gnome
     restart-delay: 1s
 
-  xdg-desktop-portal-gtk:
-    command: run.sh /usr/libexec/xdg-desktop-portal-gtk
-    daemon: dbus
-    passthrough:
-      daemon-scope: user
-      activates-on:
-        - dbus-freedesktop-impl-portal-gtk
-    restart-delay: 1s
+  #xdg-desktop-portal-gtk:
+  #  command: run.sh /usr/libexec/xdg-desktop-portal-gtk
+  #  daemon: dbus
+  #  passthrough:
+  #    daemon-scope: user
+  #    activates-on:
+  #      - dbus-freedesktop-impl-portal-gtk
+  #  restart-delay: 1s
 
   ibus-service:
     command: run.sh /usr/bin/ibus-daemon --panel disable


### PR DESCRIPTION
Drop the GTK portal to unblock gnome-shell startup, we'll enable it again when we fix the blocking issue