### PR TITLE
Make stand alone session

### DIFF
--- a/scripts/run-session.sh
+++ b/scripts/run-session.sh
@@ -20,4 +20,7 @@ if ! grep "^snap$" $HOME/.hidden 2>&1 > /dev/null; then
   echo "snap" >> $HOME/.hidden
 fi
 
+export XDG_DATA_DIRS=${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}$SNAP/usr/share
+export PATH=${PATH:+$PATH:}$SNAP/usr/bin
+
 exec $SNAP/usr/bin/gnome-shell --display-server --wayland

--- a/scripts/run-session.sh
+++ b/scripts/run-session.sh
@@ -20,4 +20,4 @@ if ! grep "^snap$" $HOME/.hidden 2>&1 > /dev/null; then
   echo "snap" >> $HOME/.hidden
 fi
 
-exec /usr/bin/gnome-session --builtin --session=ubuntu
+exec $SNAP/usr/bin/gnome-shell --display-server --wayland

--- a/scripts/run-session.sh
+++ b/scripts/run-session.sh
@@ -12,9 +12,12 @@ chmod 01777 /tmp/.X11-unix /tmp/.ICE-unix
 # Create the runtime directory
 mkdir -p --mode=700 $XDG_RUNTIME_DIR
 
-export PULSE_SERVER=unix:/run/user/`id -u`/pulse/native
+USERPATH=/run/user/`id -u`
+
+export PULSE_SERVER=unix:$USERPATH/pulse/native
 export GNOME_SHELL_SESSION_MODE=ubuntu
 export XDG_CURRENT_DESKTOP=ubuntu:GNOME
+export WAYLAND_DISPLAY=$USERPATH/wayland-0
 
 if ! grep "^snap$" $HOME/.hidden 2>&1 > /dev/null; then
   echo "snap" >> $HOME/.hidden
@@ -22,5 +25,13 @@ fi
 
 export XDG_DATA_DIRS=${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}$SNAP/usr/share
 export PATH=${PATH:+$PATH:}$SNAP/usr/bin
+
+if [ ! -f $USERPATH/wayland-0 ]; then
+  ln -s $USERPATH/snap.ubuntu-desktop-session/wayland-0 $USERPATH/wayland-0
+fi
+
+if [ ! -f $USERPATH/pulse ]; then
+  ln -s $USERPATH/snap.ubuntu-desktop-session/pulse $USERPATH/pulse
+fi
 
 exec $SNAP/usr/bin/gnome-shell --display-server --wayland

--- a/scripts/run-session.sh
+++ b/scripts/run-session.sh
@@ -26,12 +26,13 @@ fi
 export XDG_DATA_DIRS=${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}$SNAP/usr/share
 export PATH=${PATH:+$PATH:}$SNAP/usr/bin
 
-if [ ! -f $USERPATH/wayland-0 ]; then
-  ln -s $USERPATH/snap.ubuntu-desktop-session/wayland-0 $USERPATH/wayland-0
-fi
+# if [ ! -f $USERPATH/wayland-0 ]; then
+#   ln -s $USERPATH/snap.ubuntu-desktop-session/wayland-0 $USERPATH/wayland-0
+# fi
 
-if [ ! -f $USERPATH/pulse ]; then
-  ln -s $USERPATH/snap.ubuntu-desktop-session/pulse $USERPATH/pulse
-fi
+# if [ ! -f $USERPATH/pulse ]; then
+#   ln -s $USERPATH/snap.ubuntu-desktop-session/pulse $USERPATH/pulse
+# fi
 
 exec $SNAP/usr/bin/gnome-shell --display-server --wayland
+#exec $SNAP/usr/bin/gnome-session --builtin --session=ubuntu 2> ~/output2.txt > ~/output.txt

--- a/scripts/run-session.sh
+++ b/scripts/run-session.sh
@@ -35,4 +35,4 @@ export PATH=${PATH:+$PATH:}$SNAP/usr/bin
 # fi
 
 #exec $SNAP/usr/bin/gnome-shell --display-server --wayland
-exec $SNAP/usr/bin/gnome-session --builtin --session=ubuntu 2> ~/output2.txt > ~/output.txt
+exec $SNAP/usr/bin/gnome-session --builtin --session=ubuntu

--- a/scripts/run-session.sh
+++ b/scripts/run-session.sh
@@ -24,7 +24,7 @@ if ! grep "^snap$" $HOME/.hidden 2>&1 > /dev/null; then
 fi
 
 export XDG_DATA_DIRS=${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}$SNAP/usr/share
-export PATH=${PATH:+$PATH:}$SNAP/usr/bin
+export PATH=${PATH:+$PATH:}$SNAP/usr/bin:$SNAP/usr/libexec:$SNAP/gnome-platform/usr/bin:$SNAP/gnome-platform/usr/libexec
 
 # if [ ! -f $USERPATH/wayland-0 ]; then
 #   ln -s $USERPATH/snap.ubuntu-desktop-session/wayland-0 $USERPATH/wayland-0

--- a/scripts/run-session.sh
+++ b/scripts/run-session.sh
@@ -34,5 +34,5 @@ export PATH=${PATH:+$PATH:}$SNAP/usr/bin
 #   ln -s $USERPATH/snap.ubuntu-desktop-session/pulse $USERPATH/pulse
 # fi
 
-exec $SNAP/usr/bin/gnome-shell --display-server --wayland
-#exec $SNAP/usr/bin/gnome-session --builtin --session=ubuntu 2> ~/output2.txt > ~/output.txt
+#exec $SNAP/usr/bin/gnome-shell --display-server --wayland
+exec $SNAP/usr/bin/gnome-session --builtin --session=ubuntu 2> ~/output2.txt > ~/output.txt

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 export PULSE_SERVER=unix:/run/user/`id -u`/pulse/native
+export WAYLAND_DISPLAY=/run/user/`id -u`/wayland-0
+export XDG_SESSION_TYPE=wayland
 exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ environment:
   XDG_CONFIG_HOME: $SNAP_USER_COMMON/.config
   XDG_DATA_HOME: $SNAP_USER_COMMON/.local/share
   XDG_STATE_HOME: $SNAP_USER_COMMON/.local/state
-  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:$SNAP/usr/lib/gnome-settings-daemon-46:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libunity
+  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:$SNAP/usr/lib/gnome-settings-daemon-46:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libunity:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-3.0
   GSETTINGS_SCHEMA_DIR: $SNAP/usr/share/glib-2.0/schemas${GSETTINGS_SCHEMA_DIR:+:$GSETTINGS_SCHEMA_DIR}
   GI_TYPELIB_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/gnome-shell/girepository-1.0:$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}
 
@@ -33,22 +33,12 @@ layout:
     symlink: $SNAP/usr/share/gnome-shell
   /usr/share/applications:
     bind: $SNAP/usr/share/applications
-  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0:
-    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0
-  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri:
-    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri
   /usr/share/glvnd:
     symlink: $SNAP/usr/share/glvnd
   /usr/share/X11:
     symlink: $SNAP/usr/share/X11
   /usr/share/xml/iso-codes:
     symlink: $SNAP/usr/share/xml/iso-codes
-  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4:
-    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4
-  /etc/fonts:
-    bind: $SNAP/etc/fonts
-  /etc/gnome:
-    bind: $SNAP/etc/gnome
   /usr/share/fonts:
     bind: $SNAP/usr/share/fonts
   /usr/share/fontconfig:
@@ -57,18 +47,51 @@ layout:
     symlink: $SNAP/usr/share/themes
   /usr/share/icons:
     bind: $SNAP/usr/share/icons
-  /etc/mime.types:
-    bind-file: $SNAP/etc/mime.types
   /usr/share/mime:
     symlink: $SNAP/usr/share/mime
+  /usr/share/tracker3:
+    symlink: $SNAP/usr/share/tracker3
+  /usr/share/tracker3-miners:
+    symlink: $SNAP/usr/share/tracker3-miners
+
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/samba:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/samba
+
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-3.0:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-3.0
+
   /usr/libexec:
     bind: $SNAP/usr/libexec
+
+  /etc/fonts:
+    bind: $SNAP/etc/fonts
+  /etc/gnome:
+    bind: $SNAP/etc/gnome
+  /etc/mime.types:
+    bind-file: $SNAP/etc/mime.types
   /etc/profile.d/gnome-session_gnomerc.sh:
     bind-file: $SNAP/etc/profile.d/gnome-session_gnomerc.sh
   /etc/profile.d/xdg-dirs-desktop-session.sh:
     bind-file: $SNAP/etc/profile.d/xdg-dirs-desktop-session.sh
+  /etc/glvnd:
+    bind: $SNAP/etc/glvnd
+  /etc/gtk-3.0:
+    bind: $SNAP/etc/gtk-3.0
+  /etc/X11:
+    bind: $SNAP/etc/X11
+  /etc/pulse:
+    bind: $SNAP/etc/pulse
+
   /usr/bin/XWayland:
     symlink: $SNAP/usr/bin/XWayland
   /usr/bin/X11:
@@ -79,8 +102,6 @@ layout:
     symlink: $SNAP/usr/bin/xdg-user-dirs-update
   /usr/bin/gnome-session-quit:
     symlink: $SNAP/usr/bin/gnome-session-quit
-  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/samba:
-    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/samba
 
 apps:
   ubuntu-desktop-session:
@@ -99,6 +120,8 @@ apps:
       - bluez
       - cups-control
       - desktop-launch
+      - dot-hidden
+      - dot-local-share-nautilus
       - hardware-observe
       - hostname-control
       - home
@@ -113,6 +136,7 @@ apps:
       - opengl
       - polkit-agent
       - process-control
+      - shell-config-files
       - shell-session-locale-files
       - shutdown
       - ssh-keys
@@ -391,6 +415,16 @@ apps:
     restart-delay: 1s
     plugs: *pluglist
 
+  tracker:
+    command: run.sh $SNAP/usr/libexec/tracker-miner-fs-3
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-freedesktop-tracker3-miner-files
+    restart-delay: 1s
+    plugs: *pluglist
+
 plugs:
   dot-local-share-nautilus:
     interface: personal-files
@@ -408,16 +442,10 @@ plugs:
   shell-config-files:
     interface: system-files
     read:
-      - /etc/fonts
-      - /etc/glvnd
-      - /etc/gnome/defaults.list
-      - /etc/gtk-3.0
-      - /etc/pulse
       - /etc/shells
       - /etc/xdg/autostart
       - /run/udev/tags/seat
       - /etc/default/im-config
-      - /etc/X11/xinit/xinputrc
       - /etc/default/locale
 
 slots:
@@ -425,6 +453,10 @@ slots:
     interface: dbus
     bus: session
     name: com.canonical.Unity
+  dbus-freedesktop-tracker3-miner-files:
+    interface: dbus
+    bus: session
+    name: org.freedesktop.Tracker3.Miner.Files
   dbus-freedesktop-impl-portal-gnome:
     interface: dbus
     bus: session

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,19 @@ environment:
   XDG_CONFIG_HOME: $SNAP_USER_COMMON/.config
   XDG_DATA_HOME: $SNAP_USER_COMMON/.local/share
   XDG_STATE_HOME: $SNAP_USER_COMMON/.local/state
+  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14
+  GSETTINGS_SCHEMA_DIR: $SNAP/usr/share/glib-2.0/schemas${GSETTINGS_SCHEMA_DIR:+:$GSETTINGS_SCHEMA_DIR}
+  GI_TYPELIB_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/gnome-shell/girepository-1.0:$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}
+
+layout:
+  /usr/share/libinput:
+    symlink: $SNAP/usr/share/libinput
+  /usr/share/gnome-shell:
+    bind: $SNAP/usr/share/gnome-shell
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0:
+    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0
+  # /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri:
+  #   bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri
 
 apps:
   ubuntu-desktop-session:
@@ -26,6 +39,7 @@ apps:
     slots:
       - wayland
       - x11
+      - desktop
 #      - dbus-gnome-mutter-service-channel
     plugs:
       - account-control
@@ -34,30 +48,47 @@ apps:
       - timeserver-control
       - timezone-control
       - shell-session-locale-files
-
-  gnome-terminal-server:
-    command: run.sh /usr/libexec/gnome-terminal-server
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gnome-terminal
+      - avahi-control
+      - audio-playback
+      - audio-record
+      - bluez
+      - bluetooth-control
+      - cups-control
+      - desktop-launch
+      - hardware-observe
+      - hostname-control
+      - home
+      - login-session-observe
+      - login-session-control
+      - mount-observe
+      - network-bind
+      - network-control
+      - network-observe
+      - network-manager
+      - opengl
+      - polkit-agent
+      - process-control
+      - shutdown
+      - ssh-keys
+      - system-observe
+      - upower-observe
 
   screencast-service:
-    command: run.sh /usr/bin/gjs -m /usr/share/gnome-shell/org.gnome.Shell.Screencast
+    command: run.sh $SNAP/usr/bin/gjs -m /usr/share/gnome-shell/org.gnome.Shell.Screencast
     daemon: dbus
     daemon-scope: user
     activates-on:
       - dbus-gnome-shell-screencast
 
   nautilus-service:
-    command: run.sh /usr/bin/nautilus --gapplication-service
+    command: run.sh $SNAP/usr/bin/nautilus --gapplication-service
     daemon: dbus
     daemon-scope: user
     activates-on:
       - dbus-gnome-nautilus
 
   xdg-desktop-portal-gnome:
-    command: run.sh /usr/libexec/xdg-desktop-portal-gnome
+    command: run.sh $SNAP/usr/libexec/xdg-desktop-portal-gnome
     daemon: dbus
     daemon-scope: user
     activates-on:
@@ -73,41 +104,38 @@ apps:
   #  restart-delay: 1s
 
   ibus-service:
-    command: run.sh /usr/bin/ibus-daemon --panel disable
+    command: run.sh $SNAP/usr/bin/ibus-daemon --panel disable
     daemon: dbus
-    daemon-scope: user
+    passthrough:
+      daemon-scope: user
     activates-on:
       - dbus-ibus
 
   ibus-gtk3-service:
-    command: run.sh /usr/libexec/ibus-extension-gtk3
+    command: run.sh $SNAP/usr/libexec/ibus-extension-gtk3
     daemon: dbus
-    daemon-scope: user
+    passthrough:
+      daemon-scope: user
     activates-on:
       - dbus-ibus-gtk3
 
   ibus-portal-service:
-    command: run.sh /usr/libexec/ibus-portal
+    command: run.sh $SNAP/usr/libexec/ibus-portal
     daemon: dbus
-    daemon-scope: user
+    passthrough:
+      daemon-scope: user
     activates-on:
       - dbus-ibus-portal
 
   colord:
-    command: run.sh /usr/libexec/colord-session
+    command: run.sh $SNAP/usr/libexec/colord-session
     daemon: dbus
-    daemon-scope: user
+    passthrough:
+      daemon-scope: user
     activates-on:
       - dbus-colord
 
 plugs:
-  avahi-control: null
-  audio-playback: null
-  audio-record: null
-  bluez: null
-  bluetooth-control: null
-  cups-control: null
-  desktop-launch: null
   dot-local-share-nautilus:
     interface: personal-files
     write:
@@ -116,23 +144,6 @@ plugs:
     interface: personal-files
     write:
       - $HOME/.hidden
-  hardware-observe: null
-  hostname-control: null
-  home: null
-  login-session-observe: null
-  login-session-control: null
-  mount-observe: null
-  network-bind: null
-  network-control: null
-  network-observe: null
-  network-manager: null
-  opengl: null
-  #pipewire: null
-  polkit-agent: null
-  process-control: null
-  shutdown: null
-  ssh-keys: null
-  system-observe: null
   shell-session-locale-files:
     interface: personal-files
     write:
@@ -152,10 +163,8 @@ plugs:
       - /etc/default/im-config
       - /etc/X11/xinit/xinputrc
       - /etc/default/locale
-  upower-observe: null
 
 slots:
-  desktop: null
   dbus-canonical-unity:
     interface: dbus
     bus: session
@@ -385,10 +394,15 @@ slots:
     name: org.freedesktop.ColorHelper
     bus: session
 
+lint:
+  ignore:
+    - classic
+
 parts:
   scripts:
     plugin: dump
     source: ./scripts
+
   ubuntu-desktop-session:
     plugin: nil
     build-packages:
@@ -396,3 +410,60 @@ parts:
     override-build: |
       cd $CRAFT_PROJECT_DIR
       craftctl set version=$(date +%Y%m%d)+git$(git rev-parse --short HEAD)
+
+  packages:
+    plugin: nil
+    build-packages:
+      - libglib2.0-bin
+    stage-packages:
+      - alsa-ucm-conf
+      - fonts-ubuntu
+      - gir1.2-clutter-1.0
+      - gir1.2-dbusmenu-glib-0.4
+      - gir1.2-gsound-1.0
+      - gir1.2-glib-2.0-dev
+      - gkbd-capplet
+      - gnome-control-center
+      - gnome-keyring
+      - gnome-menus
+      - gnome-settings-daemon
+      - gnome-shell
+      - gnome-shell-common
+      - gnome-shell-extension-appindicator
+      - gnome-shell-extension-desktop-icons-ng
+      - gnome-shell-extension-ubuntu-dock
+      - gnome-shell-extension-ubuntu-tiling-assistant
+      - gsound-tools
+      - ibus
+      - inotify-tools
+      - libcanberra-pulse
+      - libgdk-pixbuf-2.0-0
+      - libgjs0g
+      - libgl1-mesa-dri
+      - libgsound0
+      - libpam-gnome-keyring
+      - libsnapd-glib-2-1
+      - locales-all
+      - locales
+      - polkitd
+      - pulseaudio-utils
+      - ubuntu-session
+      - ubuntu-settings
+      - xdg-desktop-portal
+      - xdg-desktop-portal-gnome
+      - xdg-desktop-portal-gtk
+      - xdg-user-dirs-gtk
+      - xdg-user-dirs
+      - xwayland
+      - yaru-theme-gtk
+      - yaru-theme-gnome-shell
+      - yaru-theme-icon
+    build-environment:
+      - LD_LIBRARY_PATH: $CRAFT_PART_INSTALL/usr/lib:$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+    override-build: |
+      glib-compile-schemas $CRAFT_PART_INSTALL/usr/share/glib-2.0/schemas
+      export CACHE=$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders.cache
+      $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders/* > $CACHE
+      sed -i "s@$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@g" $CACHE
+      craftctl default
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,35 +30,57 @@ layout:
   /usr/share/libinput:
     symlink: $SNAP/usr/share/libinput
   /usr/share/gnome-shell:
-    bind: $SNAP/usr/share/gnome-shell
+    symlink: $SNAP/usr/share/gnome-shell
+  /usr/share/applications:
+    bind: $SNAP/usr/share/applications
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0:
-    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri:
-    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri
   /usr/share/glvnd:
-    bind: $SNAP/usr/share/glvnd
+    symlink: $SNAP/usr/share/glvnd
   /usr/share/X11:
-    bind: $SNAP/usr/share/X11
+    symlink: $SNAP/usr/share/X11
   /usr/share/xml/iso-codes:
-    bind: $SNAP/usr/share/xml/iso-codes
+    symlink: $SNAP/usr/share/xml/iso-codes
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4:
-    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4
   /etc/fonts:
     bind: $SNAP/etc/fonts
+  /etc/gnome:
+    bind: $SNAP/etc/gnome
   /usr/share/fonts:
     bind: $SNAP/usr/share/fonts
   /usr/share/fontconfig:
     bind: $SNAP/usr/share/fontconfig
   /usr/share/themes:
-    bind: $SNAP/usr/share/themes
+    symlink: $SNAP/usr/share/themes
   /usr/share/icons:
     bind: $SNAP/usr/share/icons
   /etc/mime.types:
     bind-file: $SNAP/etc/mime.types
   /usr/share/mime:
-    bind: $SNAP/usr/share/mime
+    symlink: $SNAP/usr/share/mime
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0
+  /usr/libexec:
+    bind: $SNAP/usr/libexec
+  /etc/profile.d/gnome-session_gnomerc.sh:
+    bind-file: $SNAP/etc/profile.d/gnome-session_gnomerc.sh
+  /etc/profile.d/xdg-dirs-desktop-session.sh:
+    bind-file: $SNAP/etc/profile.d/xdg-dirs-desktop-session.sh
+  /usr/bin/XWayland:
+    symlink: $SNAP/usr/bin/XWayland
+  /usr/bin/X11:
+    symlink: $SNAP/usr/bin/X11
+  /usr/bin/xdg-user-dir:
+    symlink: $SNAP/usr/bin/xdg-user-dir
+  /usr/bin/xdg-user-dirs-update:
+    symlink: $SNAP/usr/bin/xdg-user-dirs-update
+  /usr/bin/gnome-session-quit:
+    symlink: $SNAP/usr/bin/gnome-session-quit
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/samba:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/samba
 
 apps:
   ubuntu-desktop-session:
@@ -95,6 +117,7 @@ apps:
       - shutdown
       - ssh-keys
       - system-observe
+      - systemd-user-control
       - time-control
       - timeserver-control
       - timezone-control
@@ -679,6 +702,7 @@ parts:
       - libgdk-pixbuf-2.0-0
       - libgjs0g
       - libgl1-mesa-dri
+      - libglib2.0-0t64
       - libgsound0
       - libpam-gnome-keyring
       - libsnapd-glib-2-1
@@ -705,11 +729,40 @@ parts:
     override-build: |
       # compile schemas
       glib-compile-schemas $CRAFT_PART_INSTALL/usr/share/glib-2.0/schemas
+
       # update pixbuf-loaders cache
       export CACHE=$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders.cache
       $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders/* > $CACHE
       sed -i "s@$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@g" $CACHE
+
       # update MIME types
       $CRAFT_PART_INSTALL/usr/bin/update-mime-database $CRAFT_PART_INSTALL/usr/share/mime
+
+      # point to the right path
+      sed -i 's@exec /usr/libexec@exec $SNAP/usr/libexec@g' $CRAFT_PART_INSTALL/usr/bin/gnome-session
+      for FILENAME in $CRAFT_PART_INSTALL/usr/share/applications/*.desktop; do
+        sed -i "s@Exec=/usr@Exec=/snap/ubuntu-desktop-session/current/usr@g" $FILENAME
+      done
+
+      # Force gsd-xsettings to use the regular DISPLAY connection. If it
+      # tries to connect to :1, gnome-shell will not auto-start Xwayland.
+      mv $CRAFT_PART_INSTALL/usr/libexec/gsd-xsettings $CRAFT_PART_INSTALL/usr/libexec/gsd-xsettings.real
+      cat <<\EOF > $CRAFT_PART_INSTALL/usr/libexec/gsd-xsettings
+      #!/bin/sh
+      export GNOME_SETUP_DISPLAY="$DISPLAY"
+      exec /usr/libexec/gsd-xsettings.real "$@"
+      EOF
+      chmod a+x $CRAFT_PART_INSTALL/usr/libexec/gsd-xsettings
+
+      # remove dependencies on ubuntu session (temporary)
+      rm -f $CRAFT_PART_INSTALL/usr/share/gnome-session/sessions/ubuntu.session
+
+      cat <<\EOF > $CRAFT_PART_INSTALL/usr/share/gnome-session/sessions/ubuntu.session
+      [GNOME Session]
+      Name=Ubuntu
+      # Must be in sync with gnome-session@ubuntu.target.d/ubuntu.session.conf drop-in
+      RequiredComponents=org.gnome.Shell;
+      EOF
+
       craftctl default
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,7 +68,7 @@ apps:
       - x11
       - desktop
 #      - dbus-gnome-mutter-service-channel
-    plugs:
+    plugs: &pluglist
       - account-control
       - audio-playback
       - audio-record
@@ -107,6 +107,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gnome-shell-screencast
+    restart-delay: 1s
+    plugs: *pluglist
 
   nautilus-service:
     command: run.sh $SNAP/usr/bin/nautilus --gapplication-service
@@ -115,6 +117,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gnome-nautilus
+    restart-delay: 1s
+    plugs: *pluglist
 
   xdg-desktop-portal-gnome:
     command: run.sh $SNAP/usr/libexec/xdg-desktop-portal-gnome
@@ -124,6 +128,7 @@ apps:
     activates-on:
       - dbus-freedesktop-impl-portal-gnome
     restart-delay: 1s
+    plugs: *pluglist
 
   #xdg-desktop-portal-gtk:
   #  command: run.sh /usr/libexec/xdg-desktop-portal-gtk
@@ -140,6 +145,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-ibus
+    restart-delay: 1s
+    plugs: *pluglist
 
   ibus-gtk3-service:
     command: run.sh $SNAP/usr/libexec/ibus-extension-gtk3
@@ -148,6 +155,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-ibus-gtk3
+    restart-delay: 1s
+    plugs: *pluglist
 
   ibus-portal-service:
     command: run.sh $SNAP/usr/libexec/ibus-portal
@@ -156,6 +165,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-ibus-portal
+    restart-delay: 1s
+    plugs: *pluglist
 
   colord:
     command: run.sh $SNAP/usr/libexec/colord-session
@@ -164,6 +175,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-colord
+    restart-delay: 1s
+    plugs: *pluglist
 
   calendar-server:
     command: run.sh $SNAP/usr/libexec/gnome-shell-calendar-server
@@ -172,6 +185,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gnome-shell-calendar-server
+    restart-delay: 1s
+    plugs: *pluglist
 
   gtk-settings:
     command: run.sh $SNAP/usr/libexec/gsd-xsettings
@@ -180,6 +195,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gtk-settings
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings:
     command: run.sh $SNAP/usr/bin/gnome-control-center
@@ -188,6 +205,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gnome-settings
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-a11y:
     command: run.sh $SNAP/usr/libexec/gsd-a11y-settings
@@ -196,6 +215,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-a11ysettings
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-color:
     command: run.sh $SNAP/usr/libexec/gsd-color
@@ -204,6 +225,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-color
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-datetime:
     command: run.sh $SNAP/usr/libexec/gsd-datetime
@@ -212,6 +235,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-datetime
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-housekeeping:
     command: run.sh $SNAP/usr/libexec/gsd-housekeeping
@@ -220,6 +245,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-housekeeping
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-keyboard:
     command: run.sh $SNAP/usr/libexec/gsd-keyboard
@@ -228,6 +255,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-keyboard
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-media-keys:
     command: run.sh $SNAP/usr/libexec/gsd-media-keys
@@ -236,6 +265,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-mediakeys
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-power:
     command: run.sh $SNAP/usr/libexec/gsd-power
@@ -244,6 +275,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-power
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-print-notifications:
     command: run.sh $SNAP/usr/libexec/gsd-print-notifications
@@ -252,6 +285,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-printnotifications
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-rfkill:
     command: run.sh $SNAP/usr/libexec/gsd-rfkill
@@ -260,6 +295,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-rfkill
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-screensaver-proxy:
     command: run.sh $SNAP/usr/libexec/gsd-screensaver-proxy
@@ -268,6 +305,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-screensaverproxy
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-sharing:
     command: run.sh $SNAP/usr/libexec/gsd-sharing
@@ -276,6 +315,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-sharing
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-smartcard:
     command: run.sh $SNAP/usr/libexec/gsd-smartcard
@@ -284,6 +325,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-smartcard
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-sound:
     command: run.sh $SNAP/usr/libexec/gsd-sound
@@ -292,6 +335,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-sound
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-usb-protection:
     command: run.sh $SNAP/usr/libexec/gsd-usd-protection
@@ -300,6 +345,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-usbprotection
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-wacom:
     command: run.sh $SNAP/usr/libexec/gsd-wacom
@@ -308,6 +355,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-wacom
+    restart-delay: 1s
+    plugs: *pluglist
 
   gnome-settings-xsettings:
     command: run.sh $SNAP/usr/libexec/gsd-xsettings
@@ -316,6 +365,8 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gsd-xsettings
+    restart-delay: 1s
+    plugs: *pluglist
 
 plugs:
   dot-local-share-nautilus:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,13 +12,17 @@ platforms:
     build-on: amd64
     build-for: all
 
+package-repositories:
+ - type: apt
+   ppa: desktop-snappers/core-desktop
+
 environment:
   HOME: $SNAP_REAL_HOME
   XDG_CACHE_HOME: $SNAP_USER_COMMON/.cache
   XDG_CONFIG_HOME: $SNAP_USER_COMMON/.config
   XDG_DATA_HOME: $SNAP_USER_COMMON/.local/share
   XDG_STATE_HOME: $SNAP_USER_COMMON/.local/state
-  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio
+  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:$SNAP/usr/lib/gnome-settings-daemon-46:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libunity
   GSETTINGS_SCHEMA_DIR: $SNAP/usr/share/glib-2.0/schemas${GSETTINGS_SCHEMA_DIR:+:$GSETTINGS_SCHEMA_DIR}
   GI_TYPELIB_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/gnome-shell/girepository-1.0:$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}
 
@@ -53,6 +57,8 @@ layout:
     bind-file: $SNAP/etc/mime.types
   /usr/share/mime:
     bind: $SNAP/usr/share/mime
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0:
+    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0
 
 apps:
   ubuntu-desktop-session:
@@ -64,21 +70,17 @@ apps:
 #      - dbus-gnome-mutter-service-channel
     plugs:
       - account-control
-      - locale-control
-      - time-control
-      - timeserver-control
-      - timezone-control
-      - shell-session-locale-files
-      - avahi-control
       - audio-playback
       - audio-record
-      - bluez
+      - avahi-control
       - bluetooth-control
+      - bluez
       - cups-control
       - desktop-launch
       - hardware-observe
       - hostname-control
       - home
+      - locale-control
       - login-session-observe
       - login-session-control
       - mount-observe
@@ -89,9 +91,13 @@ apps:
       - opengl
       - polkit-agent
       - process-control
+      - shell-session-locale-files
       - shutdown
       - ssh-keys
       - system-observe
+      - time-control
+      - timeserver-control
+      - timezone-control
       - upower-observe
 
   screencast-service:
@@ -182,6 +188,134 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-gnome-settings
+
+  gnome-settings-a11y:
+    command: run.sh $SNAP/usr/libexec/gsd-a11y-settings
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-a11ysettings
+
+  gnome-settings-color:
+    command: run.sh $SNAP/usr/libexec/gsd-color
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-color
+
+  gnome-settings-datetime:
+    command: run.sh $SNAP/usr/libexec/gsd-datetime
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-datetime
+
+  gnome-settings-housekeeping:
+    command: run.sh $SNAP/usr/libexec/gsd-housekeeping
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-housekeeping
+
+  gnome-settings-keyboard:
+    command: run.sh $SNAP/usr/libexec/gsd-keyboard
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-keyboard
+
+  gnome-settings-media-keys:
+    command: run.sh $SNAP/usr/libexec/gsd-media-keys
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-mediakeys
+
+  gnome-settings-power:
+    command: run.sh $SNAP/usr/libexec/gsd-power
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-power
+
+  gnome-settings-print-notifications:
+    command: run.sh $SNAP/usr/libexec/gsd-print-notifications
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-printnotifications
+
+  gnome-settings-rfkill:
+    command: run.sh $SNAP/usr/libexec/gsd-rfkill
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-rfkill
+
+  gnome-settings-screensaver-proxy:
+    command: run.sh $SNAP/usr/libexec/gsd-screensaver-proxy
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-screensaverproxy
+
+  gnome-settings-sharing:
+    command: run.sh $SNAP/usr/libexec/gsd-sharing
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-sharing
+
+  gnome-settings-smartcard:
+    command: run.sh $SNAP/usr/libexec/gsd-smartcard
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-smartcard
+
+  gnome-settings-sound:
+    command: run.sh $SNAP/usr/libexec/gsd-sound
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-sound
+
+  gnome-settings-usb-protection:
+    command: run.sh $SNAP/usr/libexec/gsd-usd-protection
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-usbprotection
+
+  gnome-settings-wacom:
+    command: run.sh $SNAP/usr/libexec/gsd-wacom
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-wacom
+
+  gnome-settings-xsettings:
+    command: run.sh $SNAP/usr/libexec/gsd-xsettings
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gsd-xsettings
 
 plugs:
   dot-local-share-nautilus:
@@ -292,7 +426,7 @@ slots:
   dbus-gsd:
     interface: dbus
     bus: session
-    name: org.gnome.SettingsDaemon
+    name: org.gnome.Settings
   dbus-gsd-a11ysettings:
     interface: dbus
     bus: session

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,8 +6,7 @@ description: |
 
 grade: stable
 confinement: strict
-base: core24-desktop
-build-base: core24
+base: core24
 platforms:
   all:
     build-on: amd64
@@ -19,7 +18,7 @@ environment:
   XDG_CONFIG_HOME: $SNAP_USER_COMMON/.config
   XDG_DATA_HOME: $SNAP_USER_COMMON/.local/share
   XDG_STATE_HOME: $SNAP_USER_COMMON/.local/state
-  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14
+  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio
   GSETTINGS_SCHEMA_DIR: $SNAP/usr/share/glib-2.0/schemas${GSETTINGS_SCHEMA_DIR:+:$GSETTINGS_SCHEMA_DIR}
   GI_TYPELIB_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/gnome-shell/girepository-1.0:$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}
 
@@ -30,8 +29,30 @@ layout:
     bind: $SNAP/usr/share/gnome-shell
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0
-  # /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri:
-  #   bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri:
+    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri
+  /usr/share/glvnd:
+    bind: $SNAP/usr/share/glvnd
+  /usr/share/X11:
+    bind: $SNAP/usr/share/X11
+  /usr/share/xml/iso-codes:
+    bind: $SNAP/usr/share/xml/iso-codes
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4:
+    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4
+  /etc/fonts:
+    bind: $SNAP/etc/fonts
+  /usr/share/fonts:
+    bind: $SNAP/usr/share/fonts
+  /usr/share/fontconfig:
+    bind: $SNAP/usr/share/fontconfig
+  /usr/share/themes:
+    bind: $SNAP/usr/share/themes
+  /usr/share/icons:
+    bind: $SNAP/usr/share/icons
+  /etc/mime.types:
+    bind-file: $SNAP/etc/mime.types
+  /usr/share/mime:
+    bind: $SNAP/usr/share/mime
 
 apps:
   ubuntu-desktop-session:
@@ -76,21 +97,24 @@ apps:
   screencast-service:
     command: run.sh $SNAP/usr/bin/gjs -m /usr/share/gnome-shell/org.gnome.Shell.Screencast
     daemon: dbus
-    daemon-scope: user
+    passthrough:
+      daemon-scope: user
     activates-on:
       - dbus-gnome-shell-screencast
 
   nautilus-service:
     command: run.sh $SNAP/usr/bin/nautilus --gapplication-service
     daemon: dbus
-    daemon-scope: user
+    passthrough:
+      daemon-scope: user
     activates-on:
       - dbus-gnome-nautilus
 
   xdg-desktop-portal-gnome:
     command: run.sh $SNAP/usr/libexec/xdg-desktop-portal-gnome
     daemon: dbus
-    daemon-scope: user
+    passthrough:
+      daemon-scope: user
     activates-on:
       - dbus-freedesktop-impl-portal-gnome
     restart-delay: 1s
@@ -134,6 +158,30 @@ apps:
       daemon-scope: user
     activates-on:
       - dbus-colord
+
+  calendar-server:
+    command: run.sh $SNAP/usr/libexec/gnome-shell-calendar-server
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gnome-shell-calendar-server
+
+  gtk-settings:
+    command: run.sh $SNAP/usr/libexec/gsd-xsettings
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gtk-settings
+
+  gnome-settings:
+    command: run.sh $SNAP/usr/bin/gnome-control-center
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gnome-settings
 
 plugs:
   dot-local-share-nautilus:
@@ -237,6 +285,10 @@ slots:
     interface: dbus
     bus: session
     name: org.gnome.SessionManager
+  dbus-gnome-shell-calendar-server:
+    interface: dbus
+    bus: session
+    name: org.gnome.Shell.CalendarServer
   dbus-gsd:
     interface: dbus
     bus: session
@@ -436,15 +488,19 @@ parts:
       - gsound-tools
       - ibus
       - inotify-tools
+      - iso-codes
       - libcanberra-pulse
+      - libfreetype6
       - libgdk-pixbuf-2.0-0
       - libgjs0g
       - libgl1-mesa-dri
       - libgsound0
       - libpam-gnome-keyring
       - libsnapd-glib-2-1
+      - libsysmetrics1
       - locales-all
       - locales
+      - media-types
       - polkitd
       - pulseaudio-utils
       - ubuntu-session
@@ -454,6 +510,7 @@ parts:
       - xdg-desktop-portal-gtk
       - xdg-user-dirs-gtk
       - xdg-user-dirs
+      - xkb-data
       - xwayland
       - yaru-theme-gtk
       - yaru-theme-gnome-shell
@@ -461,9 +518,13 @@ parts:
     build-environment:
       - LD_LIBRARY_PATH: $CRAFT_PART_INSTALL/usr/lib:$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
     override-build: |
+      # compile schemas
       glib-compile-schemas $CRAFT_PART_INSTALL/usr/share/glib-2.0/schemas
+      # update pixbuf-loaders cache
       export CACHE=$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders.cache
       $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders/* > $CACHE
       sed -i "s@$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@g" $CACHE
+      # update MIME types
+      $CRAFT_PART_INSTALL/usr/bin/update-mime-database $CRAFT_PART_INSTALL/usr/share/mime
       craftctl default
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -63,6 +63,8 @@ layout:
     symlink: $SNAP/usr/share/gtk-4.0
   /usr/share/defaults:
     symlink: $SNAP/usr/share/defaults
+  /usr/share/xdg-desktop-portal:
+    symlink: $SNAP/usr/share/xdg-desktop-portal
 
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30:
     symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30
@@ -103,10 +105,12 @@ layout:
   /etc/pulse:
     bind: $SNAP/etc/pulse
 
-  /usr/bin/XWayland:
-    symlink: $SNAP/usr/bin/XWayland
+  /usr/bin/Xwayland:
+    symlink: $SNAP/usr/bin/Xwayland
   /usr/bin/X11:
     symlink: $SNAP/usr/bin/X11
+  /usr/bin/xkbcomp:
+    symlink: $SNAP/usr/bin/xkbcomp
   /usr/bin/xdg-user-dir:
     symlink: $SNAP/usr/bin/xdg-user-dir
   /usr/bin/xdg-user-dirs-update:
@@ -117,10 +121,52 @@ layout:
 apps:
   ubuntu-desktop-session:
     command: run-session.sh
-    slots:
+    slots: &slotlist
       - wayland
       - x11
       - desktop
+      - dbus-gnome-mutter-screencast
+      - dbus-gnome-nautilus
+      - dbus-freedesktop-impl-portal-gnome
+      - dbus-freedesktop-impl-portal-gtk
+      - dbus-ibus
+      - dbus-ibus-gtk3
+      - dbus-ibus-portal
+      - dbus-colord
+      - dbus-gnome-shell-calendar-server
+      - dbus-gtk-settings
+      - dbus-gnome-settings
+      - dbus-gsd-a11ysettings
+      - dbus-gsd-color
+      - dbus-gsd-datetime
+      - dbus-gsd-housekeeping
+      - dbus-gsd-keyboard
+      - dbus-gsd-mediakeys
+      - dbus-gsd-power
+      - dbus-gsd-printnotifications
+      - dbus-gsd-rfkill
+      - dbus-gsd-screensaverproxy
+      - dbus-gsd-sharing
+      - dbus-gsd-smartcard
+      - dbus-gsd-sound
+      - dbus-gsd-usbprotection
+      - dbus-gsd-wacom
+      - dbus-gsd-xsettings
+      - dbus-freedesktop-tracker3-miner-files
+      - dbus-a11y-bus
+      - dbus-freedesktop-impl-portal-screen-cast
+      - dbus-freedesktop-impl-portal-dynamic-launcher
+      - dbus-freedesktop-impl-portal-wallpaper
+      - dbus-freedesktop-impl-portal-screenshot
+      - dbus-freedesktop-impl-portal-print
+      - dbus-freedesktop-impl-portal-lockdown
+      - dbus-freedesktop-impl-portal-background
+      - dbus-freedesktop-impl-portal-appchooser
+      - dbus-freedesktop-impl-portal-account
+      - dbus-freedesktop-impl-portal-access
+      - dbus-freedesktop-impl-portal-filechooser
+      - dbus-freedesktop-impl-portal-settings
+
 #      - dbus-gnome-mutter-service-channel
     plugs: &pluglist
       - account-control
@@ -152,7 +198,6 @@ apps:
       - shutdown
       - ssh-keys
       - system-observe
-      - systemd-user-control
       - time-control
       - timeserver-control
       - timezone-control
@@ -166,8 +211,7 @@ apps:
       - dbus-gnome-mutter-screencast
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gnome-mutter-screencast
+    slots: *slotlist
 
   nautilus-service:
     command: run.sh $SNAP/usr/bin/nautilus --gapplication-service
@@ -177,8 +221,7 @@ apps:
       - dbus-gnome-nautilus
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gnome-nautilus
+    slots: *slotlist
 
   xdg-desktop-portal-gnome:
     command: run.sh $SNAP/usr/libexec/xdg-desktop-portal-gnome
@@ -188,8 +231,7 @@ apps:
       - dbus-freedesktop-impl-portal-gnome
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-freedesktop-impl-portal-gnome
+    slots: *slotlist
 
   xdg-desktop-portal-gtk:
     command: run.sh /usr/libexec/xdg-desktop-portal-gtk
@@ -198,8 +240,7 @@ apps:
     activates-on:
       - dbus-freedesktop-impl-portal-gtk
     restart-delay: 1s
-    slots:
-      - dbus-freedesktop-impl-portal-gtk
+    slots: *slotlist
 
   ibus-service:
     command: run.sh $SNAP/usr/bin/ibus-daemon --panel disable
@@ -209,8 +250,7 @@ apps:
       - dbus-ibus
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-ibus
+    slots: *slotlist
 
   ibus-gtk3-service:
     command: run.sh $SNAP/usr/libexec/ibus-extension-gtk3
@@ -220,8 +260,7 @@ apps:
       - dbus-ibus-gtk3
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-ibus-gtk3
+    slots: *slotlist
 
   ibus-portal-service:
     command: run.sh $SNAP/usr/libexec/ibus-portal
@@ -231,8 +270,7 @@ apps:
       - dbus-ibus-portal
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-ibus-portal
+    slots: *slotlist
 
   colord:
     command: run.sh $SNAP/usr/libexec/colord-session
@@ -242,8 +280,7 @@ apps:
       - dbus-colord
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-colord
+    slots: *slotlist
 
   calendar-server:
     command: run.sh $SNAP/usr/libexec/gnome-shell-calendar-server
@@ -253,8 +290,7 @@ apps:
       - dbus-gnome-shell-calendar-server
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gnome-shell-calendar-server
+    slots: *slotlist
 
   gtk-settings:
     command: run.sh $SNAP/usr/libexec/gsd-xsettings
@@ -264,8 +300,7 @@ apps:
       - dbus-gtk-settings
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gtk-settings
+    slots: *slotlist
 
   gnome-settings:
     command: run.sh $SNAP/usr/bin/gnome-control-center
@@ -275,8 +310,7 @@ apps:
       - dbus-gnome-settings
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gnome-settings
+    slots: *slotlist
 
   gnome-settings-a11y:
     command: run.sh $SNAP/usr/libexec/gsd-a11y-settings
@@ -286,8 +320,7 @@ apps:
       - dbus-gsd-a11ysettings
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-a11ysettings
+    slots: *slotlist
 
   gnome-settings-color:
     command: run.sh $SNAP/usr/libexec/gsd-color
@@ -297,8 +330,7 @@ apps:
       - dbus-gsd-color
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-color
+    slots: *slotlist
 
   gnome-settings-datetime:
     command: run.sh $SNAP/usr/libexec/gsd-datetime
@@ -308,8 +340,7 @@ apps:
       - dbus-gsd-datetime
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-datetime
+    slots: *slotlist
 
   gnome-settings-housekeeping:
     command: run.sh $SNAP/usr/libexec/gsd-housekeeping
@@ -319,8 +350,7 @@ apps:
       - dbus-gsd-housekeeping
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-housekeeping
+    slots: *slotlist
 
   gnome-settings-keyboard:
     command: run.sh $SNAP/usr/libexec/gsd-keyboard
@@ -330,8 +360,7 @@ apps:
       - dbus-gsd-keyboard
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-keyboard
+    slots: *slotlist
 
   gnome-settings-media-keys:
     command: run.sh $SNAP/usr/libexec/gsd-media-keys
@@ -341,8 +370,7 @@ apps:
       - dbus-gsd-mediakeys
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-mediakeys
+    slots: *slotlist
 
   gnome-settings-power:
     command: run.sh $SNAP/usr/libexec/gsd-power
@@ -352,8 +380,7 @@ apps:
       - dbus-gsd-power
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-power
+    slots: *slotlist
 
   gnome-settings-print-notifications:
     command: run.sh $SNAP/usr/libexec/gsd-print-notifications
@@ -363,8 +390,7 @@ apps:
       - dbus-gsd-printnotifications
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-printnotifications
+    slots: *slotlist
 
   gnome-settings-rfkill:
     command: run.sh $SNAP/usr/libexec/gsd-rfkill
@@ -374,8 +400,7 @@ apps:
       - dbus-gsd-rfkill
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-rfkill
+    slots: *slotlist
 
   gnome-settings-screensaver-proxy:
     command: run.sh $SNAP/usr/libexec/gsd-screensaver-proxy
@@ -385,8 +410,7 @@ apps:
       - dbus-gsd-screensaverproxy
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-screensaverproxy
+    slots: *slotlist
 
   gnome-settings-sharing:
     command: run.sh $SNAP/usr/libexec/gsd-sharing
@@ -396,8 +420,7 @@ apps:
       - dbus-gsd-sharing
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-sharing
+    slots: *slotlist
 
   gnome-settings-smartcard:
     command: run.sh $SNAP/usr/libexec/gsd-smartcard
@@ -407,8 +430,7 @@ apps:
       - dbus-gsd-smartcard
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-smartcard
+    slots: *slotlist
 
   gnome-settings-sound:
     command: run.sh $SNAP/usr/libexec/gsd-sound
@@ -418,8 +440,7 @@ apps:
       - dbus-gsd-sound
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-sound
+    slots: *slotlist
 
   gnome-settings-usb-protection:
     command: run.sh $SNAP/usr/libexec/gsd-usd-protection
@@ -429,8 +450,7 @@ apps:
       - dbus-gsd-usbprotection
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-usbprotection
+    slots: *slotlist
 
   gnome-settings-wacom:
     command: run.sh $SNAP/usr/libexec/gsd-wacom
@@ -440,8 +460,7 @@ apps:
       - dbus-gsd-wacom
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-wacom
+    slots: *slotlist
 
   gnome-settings-xsettings:
     command: run.sh $SNAP/usr/libexec/gsd-xsettings
@@ -451,8 +470,7 @@ apps:
       - dbus-gsd-xsettings
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-gsd-xsettings
+    slots: *slotlist
 
   tracker:
     command: run.sh $SNAP/usr/libexec/tracker-miner-fs-3
@@ -462,8 +480,7 @@ apps:
       - dbus-freedesktop-tracker3-miner-files
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-freedesktop-tracker3-miner-files
+    slots: *slotlist
 
   a11ybus:
     command: run.sh /usr/libexec/at-spi-bus-launcher --launch-immediately
@@ -473,8 +490,7 @@ apps:
       - dbus-a11y-bus
     restart-delay: 1s
     plugs: *pluglist
-    slots:
-      - dbus-a11y-bus
+    slots: *slotlist
 
 plugs:
   dot-local-share-nautilus:
@@ -528,6 +544,54 @@ slots:
     interface: dbus
     bus: session
     name: org.freedesktop.impl.portal.desktop.gnome
+  dbus-freedesktop-impl-portal-settings:
+    interface: dbus
+    bus: session
+    name: org.freedesktop.impl.portal.desktop.settings
+  dbus-freedesktop-impl-portal-filechooser:
+    interface: dbus
+    bus: session
+    name: org.freedesktop.impl.portal.desktop.FileChooser
+  dbus-freedesktop-impl-portal-access:
+    interface: dbus
+    bus: session
+    name: org.freedesktop.impl.portal.desktop.Access
+  dbus-freedesktop-impl-portal-account:
+    interface: dbus
+    bus: session
+    name: org.freedesktop.impl.portal.desktop.Account
+  dbus-freedesktop-impl-portal-appchooser:
+    interface: dbus
+    bus: session
+    name: org.freedesktop.impl.portal.desktop.AppChooser
+  dbus-freedesktop-impl-portal-background:
+    interface: dbus
+    bus: session
+    name: org.freedesktop.impl.portal.desktop.Background
+  dbus-freedesktop-impl-portal-lockdown:
+    interface: dbus
+    bus: session
+    name: org.freedesktop.impl.portal.desktop.Lockdown
+  dbus-freedesktop-impl-portal-print:
+    interface: dbus
+    bus: session
+    name: org.freedesktop.impl.portal.desktop.Print
+  dbus-freedesktop-impl-portal-screenshot:
+    interface: dbus
+    bus: session
+    name: org.freedesktop.impl.portal.desktop.Screenshot
+  dbus-freedesktop-impl-portal-wallpaper:
+    interface: dbus
+    bus: session
+    name: org.freedesktop.impl.portal.desktop.Wallpaper
+  dbus-freedesktop-impl-portal-dynamic-launcher:
+    interface: dbus
+    bus: session
+    name: org.freedesktop.impl.portal.desktop.DynamicLauncher
+  dbus-freedesktop-impl-portal-screen-cast:
+    interface: dbus
+    bus: session
+    name: org.freedesktop.impl.portal.desktop.ScreenCast
   dbus-freedesktop-impl-portal-gtk:
     interface: dbus
     bus: session
@@ -796,6 +860,7 @@ parts:
       - gnome-shell-extension-ubuntu-tiling-assistant
       - gsound-tools
       - ibus
+      - im-config
       - inotify-tools
       - iso-codes
       - libcanberra-pulse
@@ -862,7 +927,8 @@ parts:
       [GNOME Session]
       Name=Ubuntu
       # Must be in sync with gnome-session@ubuntu.target.d/ubuntu.session.conf drop-in
-      RequiredComponents=org.gnome.Shell;
+      RequiredComponents=org.gnome.Shell;org.gnome.SettingsDaemon.A11ySettings;org.gnome.SettingsDaemon.Datetime;org.gnome.SettingsDaemon.Housekeeping;org.gnome.SettingsDaemon.Keyboard;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.PrintNotifications;org.gnome.SettingsDaemon.Rfkill;org.gnome.SettingsDaemon.ScreensaverProxy;org.gnome.SettingsDaemon.Sharing;org.gnome.SettingsDaemon.Smartcard;org.gnome.SettingsDaemon.Sound;org.gnome.SettingsDaemon.Wacom;
+      #org.gnome.SettingsDaemon.XSettings;
       EOF
 
       craftctl default

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -225,21 +225,11 @@ apps:
 
   xdg-desktop-portal-gnome:
     command: run.sh $SNAP/usr/libexec/xdg-desktop-portal-gnome
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-freedesktop-impl-portal-gnome
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
   xdg-desktop-portal-gtk:
     command: run.sh $SNAP/usr/libexec/xdg-desktop-portal-gtk
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-freedesktop-impl-portal-gtk
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
@@ -295,11 +285,6 @@ apps:
 
   gtk-settings:
     command: run.sh $SNAP/usr/libexec/gsd-xsettings
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gtk-settings
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
@@ -315,11 +300,6 @@ apps:
 
   gnome-settings-a11y:
     command: run.sh $SNAP/usr/libexec/gsd-a11y-settings
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-a11ysettings
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
@@ -335,111 +315,56 @@ apps:
 
   gnome-settings-datetime:
     command: run.sh $SNAP/usr/libexec/gsd-datetime
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-datetime
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
   gnome-settings-housekeeping:
     command: run.sh $SNAP/usr/libexec/gsd-housekeeping
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-housekeeping
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
   gnome-settings-keyboard:
     command: run.sh $SNAP/usr/libexec/gsd-keyboard
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-keyboard
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
   gnome-settings-media-keys:
     command: run.sh $SNAP/usr/libexec/gsd-media-keys
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-mediakeys
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
   gnome-settings-power:
     command: run.sh $SNAP/usr/libexec/gsd-power
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-power
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
   gnome-settings-print-notifications:
     command: run.sh $SNAP/usr/libexec/gsd-print-notifications
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-printnotifications
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
   gnome-settings-rfkill:
     command: run.sh $SNAP/usr/libexec/gsd-rfkill
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-rfkill
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
   gnome-settings-screensaver-proxy:
     command: run.sh $SNAP/usr/libexec/gsd-screensaver-proxy
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-screensaverproxy
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
   gnome-settings-sharing:
     command: run.sh $SNAP/usr/libexec/gsd-sharing
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-sharing
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
   gnome-settings-smartcard:
     command: run.sh $SNAP/usr/libexec/gsd-smartcard
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-smartcard
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
   gnome-settings-sound:
     command: run.sh $SNAP/usr/libexec/gsd-sound
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-sound
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
@@ -455,21 +380,11 @@ apps:
 
   gnome-settings-wacom:
     command: run.sh $SNAP/usr/libexec/gsd-wacom
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-wacom
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
   gnome-settings-xsettings:
     command: run.sh $SNAP/usr/libexec/gsd-xsettings
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-xsettings
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
@@ -928,8 +843,7 @@ parts:
       [GNOME Session]
       Name=Ubuntu
       # Must be in sync with gnome-session@ubuntu.target.d/ubuntu.session.conf drop-in
-      RequiredComponents=org.gnome.Shell;org.gnome.SettingsDaemon.A11ySettings;org.gnome.SettingsDaemon.Datetime;org.gnome.SettingsDaemon.Housekeeping;org.gnome.SettingsDaemon.Keyboard;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.PrintNotifications;org.gnome.SettingsDaemon.Rfkill;org.gnome.SettingsDaemon.ScreensaverProxy;org.gnome.SettingsDaemon.Sharing;org.gnome.SettingsDaemon.Smartcard;org.gnome.SettingsDaemon.Sound;org.gnome.SettingsDaemon.Wacom;
-      #org.gnome.SettingsDaemon.XSettings;
+      RequiredComponents=org.gnome.Shell;org.gnome.SettingsDaemon.A11ySettings;org.gnome.SettingsDaemon.Datetime;org.gnome.SettingsDaemon.Housekeeping;org.gnome.SettingsDaemon.Keyboard;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.PrintNotifications;org.gnome.SettingsDaemon.Rfkill;org.gnome.SettingsDaemon.ScreensaverProxy;org.gnome.SettingsDaemon.Sharing;org.gnome.SettingsDaemon.Smartcard;org.gnome.SettingsDaemon.Sound;org.gnome.SettingsDaemon.Wacom;org.gnome.SettingsDaemon.XSettings;
       EOF
 
       craftctl default

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -234,12 +234,13 @@ apps:
     slots: *slotlist
 
   xdg-desktop-portal-gtk:
-    command: run.sh /usr/libexec/xdg-desktop-portal-gtk
+    command: run.sh $SNAP/usr/libexec/xdg-desktop-portal-gtk
     daemon: dbus
     daemon-scope: user
     activates-on:
       - dbus-freedesktop-impl-portal-gtk
     restart-delay: 1s
+    plugs: *pluglist
     slots: *slotlist
 
   ibus-service:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,10 +22,11 @@ environment:
   XDG_CONFIG_HOME: $SNAP_USER_COMMON/.config
   XDG_DATA_HOME: $SNAP_USER_COMMON/.local/share
   XDG_STATE_HOME: $SNAP_USER_COMMON/.local/state
-  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/lib:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:$SNAP/usr/lib/gnome-settings-daemon-46:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libunity:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gpu-2404/usr/lib:$SNAP/gpu-2404/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gvfs
+  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libunity:$SNAP/gpu-2404/usr/lib:$SNAP/gpu-2404/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/lib:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:$SNAP/usr/lib/gnome-settings-daemon-46:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gvfs
   GSETTINGS_SCHEMA_DIR: $SNAP/gnome-platform/usr/share/glib-2.0/schemas:$SNAP/usr/share/glib-2.0/schemas${GSETTINGS_SCHEMA_DIR:+:$GSETTINGS_SCHEMA_DIR}
   GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$SNAP/gnome-platform/usr/lib/girepository-1.0:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/gnome-shell/girepository-1.0:$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}
   SNAP_DESKTOP_RUNTIME: $SNAP/gnome-platform
+  PATH: /bin:/usr/bin:$SNAP/bin:$SNAP/usr/bin:$SNAP/usr/libexec:$SNAP/gnome-platform/bin:$SNAP/gnome-platform/usr/bin:$SNAP/gnome-platform/usr/libexec${PATH:+:$PATH}
 
 layout:
   /usr/share/libinput:
@@ -53,7 +54,7 @@ layout:
   /usr/share/icons:
     bind: $SNAP/usr/share/icons
   /usr/share/mime:
-    symlink: $SNAP/usr/share/mime
+    symlink: $SNAP/gnome-platform/usr/share/mime
   /usr/share/tracker3:
     symlink: $SNAP/usr/share/tracker3
   /usr/share/tracker3-miners:
@@ -70,6 +71,56 @@ layout:
     symlink: $SNAP/gnome-platform/usr/share/defaults
   /usr/share/xdg-desktop-portal:
     symlink: $SNAP/usr/share/xdg-desktop-portal
+
+  /usr/share/dbus-1/interfaces/org.freedesktop.Accounts.User.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.Accounts.User.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.Tracker3.Miner.Files.Index.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.Tracker3.Miner.Files.Index.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.Accounts.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.Accounts.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.Tracker3.Miner.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.Tracker3.Miner.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.ColorHelper.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.ColorHelper.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.UPower.Device.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.UPower.Device.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.ColorManager.Device.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.ColorManager.Device.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.UPower.KbdBacklight.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.UPower.KbdBacklight.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.ColorManager.Profile.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.ColorManager.Profile.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.UPower.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.UPower.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.ColorManager.Sensor.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.ColorManager.Sensor.xml
+  /usr/share/dbus-1/interfaces/org.gnome.Shell.Extensions.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.gnome.Shell.Extensions.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.ColorManager.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.ColorManager.xml
+  /usr/share/dbus-1/interfaces/org.gnome.Shell.Introspect.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.gnome.Shell.Introspect.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.GeoClue2.Agent.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.GeoClue2.Agent.xml
+  /usr/share/dbus-1/interfaces/org.gnome.Shell.PadOsd.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.gnome.Shell.PadOsd.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.GeoClue2.Client.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.GeoClue2.Client.xml
+  /usr/share/dbus-1/interfaces/org.gnome.Shell.Screencast.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.gnome.Shell.Screencast.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.GeoClue2.Location.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.GeoClue2.Location.xml
+  /usr/share/dbus-1/interfaces/org.gnome.Shell.Screenshot.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.gnome.Shell.Screenshot.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.GeoClue2.Manager.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.GeoClue2.Manager.xml
+  /usr/share/dbus-1/interfaces/org.gnome.ShellSearchProvider2.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.gnome.ShellSearchProvider2.xml
+  /usr/share/dbus-1/interfaces/org.freedesktop.GeoClue2.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.GeoClue2.xml
+  /usr/share/dbus-1/interfaces/org.gnome.ShellSearchProvider.xml:
+    symlink: $SNAP/usr/share/dbus-1/interfaces/org.gnome.ShellSearchProvider.xml
+
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30:
     symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0:
@@ -96,8 +147,6 @@ layout:
     bind: $SNAP/gnome-platform/etc/fonts
   /etc/gnome:
     bind: $SNAP/etc/gnome
-  /etc/mime.types:
-    bind-file: $SNAP/etc/mime.types
   /etc/profile.d/gnome-session_gnomerc.sh:
     bind-file: $SNAP/etc/profile.d/gnome-session_gnomerc.sh
   /etc/profile.d/xdg-dirs-desktop-session.sh:
@@ -110,6 +159,14 @@ layout:
     bind: $SNAP/gnome-platform/etc/X11
   /etc/pulse:
     bind: $SNAP/gnome-platform/etc/pulse
+  /etc/xdg/Xwayland-session.d:
+    bind: $SNAP/etc/xdg/Xwayland-session.d
+  /etc/xdg/menus:
+    symlink: $SNAP/etc/xdg/menus
+  /etc/xdg/xdg/user-dirs.conf:
+    symlink: $SNAP/gnome-platform/etc/xdg/user-dirs.conf
+  /etc/xdg/xdg/user-dirs.defaults:
+    symlink: $SNAP/gnome-platform/etc/xdg/user-dirs.defaults
 
   /usr/bin/Xwayland:
     symlink: $SNAP/usr/bin/Xwayland
@@ -134,17 +191,14 @@ layout:
     bind: $SNAP/gpu-2404/libdrm
   /usr/share/drirc.d:
     symlink: $SNAP/gpu-2404/drirc.d
-  /usr/share/X11/XErrorDB:
-    symlink: $SNAP/gpu-2404/X11/XErrorDB
 
 assumes:
 - snapd2.43
 hooks:
   configure:
     command-chain:
-      - snap/command-chain/hooks-configure-fonts
-    plugs:
-      - desktop
+      - command-chain/hooks-configure-fonts
+
 
 apps:
   ubuntu-desktop-session:
@@ -288,6 +342,16 @@ apps:
     activates-on:
       - dbus-colord
     restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
+
+  screensaver:
+    command: run.sh gjs -m /usr/share/gnome-shell/org.gnome.ScreenSaver
+    daemon: dbus
+    passthrough:
+      daemon-scope: user
+    activates-on:
+      - dbus-gnome-screensaver
     plugs: *pluglist
     slots: *slotlist
 
@@ -503,7 +567,6 @@ slots:
     interface: dbus
     bus: session
     name: org.kde.StatusNotifierWatcher
-
   dbus-freedesktop-screensaver:
     interface: dbus
     bus: session
@@ -725,8 +788,13 @@ parts:
       - yaru-theme-icon
     build-environment:
       - LD_LIBRARY_PATH: $CRAFT_PART_INSTALL/usr/lib:$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-    build-snaps: [core24, gtk-common-themes, gnome-46-2404, mesa-2404]
+    build-snaps:
+      - core24
+      - gtk-common-themes
+      - gnome-46-2404
+      - mesa-2404
     override-build: |
+
       # remove duplicated files
       $CRAFT_PROJECT_DIR/snapbuildtools/remove_common.py -e usr/libexec usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0
       # delete empty folders
@@ -734,14 +802,6 @@ parts:
 
       # compile schemas
       glib-compile-schemas $CRAFT_PART_INSTALL/usr/share/glib-2.0/schemas
-
-      # update pixbuf-loaders cache
-      #export CACHE=$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders.cache
-      #$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders/* > $CACHE
-      #sed -i "s@$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@g" $CACHE
-
-      # update MIME types
-      #$CRAFT_PART_INSTALL/usr/bin/update-mime-database $CRAFT_PART_INSTALL/usr/share/mime
 
       # point to the right path
       sed -i 's@exec /usr/libexec@exec $SNAP/usr/libexec@g' $CRAFT_PART_INSTALL/usr/bin/gnome-session
@@ -765,4 +825,13 @@ parts:
       # delete the doc folders
       rm -rf $CRAFT_PART_INSTALL/usr/share/doc
       craftctl default
+
+  command-chain:
+    source: https://github.com/snapcore/snapcraft-desktop-integration.git
+    source-type: git
+    source-subdir: gnome
+    plugin: make
+    make-parameters:
+      - PLATFORM_PLUG=$SNAPCRAFT_PROJECT_NAME
+      - WITH_GRAPHICS=false
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,27 +22,32 @@ environment:
   XDG_CONFIG_HOME: $SNAP_USER_COMMON/.config
   XDG_DATA_HOME: $SNAP_USER_COMMON/.local/share
   XDG_STATE_HOME: $SNAP_USER_COMMON/.local/state
-  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:$SNAP/usr/lib/gnome-settings-daemon-46:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libunity:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30
-  GSETTINGS_SCHEMA_DIR: $SNAP/usr/share/glib-2.0/schemas${GSETTINGS_SCHEMA_DIR:+:$GSETTINGS_SCHEMA_DIR}
-  GI_TYPELIB_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/gnome-shell/girepository-1.0:$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}
+  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/lib:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:$SNAP/usr/lib/gnome-settings-daemon-46:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libunity:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gpu-2404/usr/lib:$SNAP/gpu-2404/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gvfs
+  GSETTINGS_SCHEMA_DIR: $SNAP/gnome-platform/usr/share/glib-2.0/schemas:$SNAP/usr/share/glib-2.0/schemas${GSETTINGS_SCHEMA_DIR:+:$GSETTINGS_SCHEMA_DIR}
+  GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$SNAP/gnome-platform/usr/lib/girepository-1.0:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/gnome-shell/girepository-1.0:$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}
+  SNAP_DESKTOP_RUNTIME: $SNAP/gnome-platform
 
 layout:
   /usr/share/libinput:
-    symlink: $SNAP/usr/share/libinput
+    symlink: $SNAP/gnome-platform/usr/share/libinput
+  /usr/share/xml/iso-codes:
+    symlink: $SNAP/gnome-platform/usr/share/xml/iso-codes
   /usr/share/gnome-shell:
     symlink: $SNAP/usr/share/gnome-shell
   /usr/share/applications:
     bind: $SNAP/usr/share/applications
   /usr/share/glvnd:
-    symlink: $SNAP/usr/share/glvnd
+    symlink: $SNAP/gpu-2404/usr/share/glvnd
   /usr/share/X11:
-    symlink: $SNAP/usr/share/X11
-  /usr/share/xml/iso-codes:
-    symlink: $SNAP/usr/share/xml/iso-codes
+    symlink: $SNAP/gnome-platform/usr/share/X11
+  /usr/share/egl:
+    symlink: $SNAP/gpu-2404/usr/share/egl
+  /usr/share/vulkan:
+    symlink: $SNAP/gpu-2404/usr/share/vulkan
   /usr/share/fonts:
-    bind: $SNAP/usr/share/fonts
+    bind: $SNAP/gnome-platform/usr/share/fonts
   /usr/share/fontconfig:
-    bind: $SNAP/usr/share/fontconfig
+    bind: $SNAP/gnome-platform/usr/share/fontconfig
   /usr/share/themes:
     symlink: $SNAP/usr/share/themes
   /usr/share/icons:
@@ -54,26 +59,27 @@ layout:
   /usr/share/tracker3-miners:
     symlink: $SNAP/usr/share/tracker3-miners
   /usr/share/libwacom:
-    symlink: $SNAP/usr/share/libwacom
+    symlink: $SNAP/gnome-platform/usr/share/libwacom
   /usr/share/nautilus:
     symlink: $SNAP/usr/share/nautilus
   /usr/share/gtk-3.0:
-    symlink: $SNAP/usr/share/gtk-3.0
+    symlink: $SNAP/gnome-platform/usr/share/gtk-3.0
   /usr/share/gtk-4.0:
-    symlink: $SNAP/usr/share/gtk-4.0
+    symlink: $SNAP/gnome-platform/usr/share/gtk-4.0
   /usr/share/defaults:
-    symlink: $SNAP/usr/share/defaults
+    symlink: $SNAP/gnome-platform/usr/share/defaults
   /usr/share/xdg-desktop-portal:
     symlink: $SNAP/usr/share/xdg-desktop-portal
-
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30:
     symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0:
-    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0
+    symlink: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri:
-    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri
+    symlink: $SNAP/gpu-2404/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/vdpau:
+    symlink: $SNAP/gpu-2404/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/vdpau
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4:
-    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4
+    symlink: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/samba:
@@ -87,7 +93,7 @@ layout:
     bind: $SNAP/usr/libexec
 
   /etc/fonts:
-    bind: $SNAP/etc/fonts
+    bind: $SNAP/gnome-platform/etc/fonts
   /etc/gnome:
     bind: $SNAP/etc/gnome
   /etc/mime.types:
@@ -99,11 +105,11 @@ layout:
   /etc/glvnd:
     bind: $SNAP/etc/glvnd
   /etc/gtk-3.0:
-    bind: $SNAP/etc/gtk-3.0
+    bind: $SNAP/gnome-platform/etc/gtk-3.0
   /etc/X11:
-    bind: $SNAP/etc/X11
+    bind: $SNAP/gnome-platform/etc/X11
   /etc/pulse:
-    bind: $SNAP/etc/pulse
+    bind: $SNAP/gnome-platform/etc/pulse
 
   /usr/bin/Xwayland:
     symlink: $SNAP/usr/bin/Xwayland
@@ -117,14 +123,33 @@ layout:
     symlink: $SNAP/usr/bin/xdg-user-dirs-update
   /usr/bin/gnome-session-quit:
     symlink: $SNAP/usr/bin/gnome-session-quit
+  /usr/share/session-migration:
+    symlink: $SNAP/gnome-platform/usr/share/session-migration
+
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/webkit2gtk-4.0:
+    bind: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/webkit2gtk-4.0
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/webkit2gtk-4.1:
+    bind: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/webkit2gtk-4.1
+  /usr/share/libdrm:
+    bind: $SNAP/gpu-2404/libdrm
+  /usr/share/drirc.d:
+    symlink: $SNAP/gpu-2404/drirc.d
+  /usr/share/X11/XErrorDB:
+    symlink: $SNAP/gpu-2404/X11/XErrorDB
+
+assumes:
+- snapd2.43
+hooks:
+  configure:
+    command-chain:
+      - snap/command-chain/hooks-configure-fonts
+    plugs:
+      - desktop
 
 apps:
   ubuntu-desktop-session:
     command: run-session.sh
     slots: &slotlist
-      - wayland
-      - x11
-      - desktop
       - dbus-gnome-mutter-screencast
       - dbus-gnome-nautilus
       - dbus-freedesktop-impl-portal-gnome
@@ -166,6 +191,9 @@ apps:
       - dbus-freedesktop-impl-portal-access
       - dbus-freedesktop-impl-portal-filechooser
       - dbus-freedesktop-impl-portal-settings
+      - desktop
+      - wayland
+      - x11
 
 #      - dbus-gnome-mutter-service-channel
     plugs: &pluglist
@@ -245,11 +273,11 @@ apps:
 
   ibus-portal-service:
     command: run.sh $SNAP/usr/libexec/ibus-portal
+    restart-delay: 1s
     daemon: dbus
     daemon-scope: user
     activates-on:
       - dbus-ibus-portal
-    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
@@ -259,66 +287,6 @@ apps:
     daemon-scope: user
     activates-on:
       - dbus-colord
-    restart-delay: 1s
-    plugs: *pluglist
-    slots: *slotlist
-
-  calendar-server:
-    command: run.sh $SNAP/usr/libexec/gnome-shell-calendar-server
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gnome-shell-calendar-server
-    restart-delay: 1s
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings:
-    command: run.sh $SNAP/usr/bin/gnome-control-center
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gnome-settings
-    restart-delay: 1s
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings-color:
-    command: run.sh $SNAP/usr/libexec/gsd-color
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-color
-    restart-delay: 1s
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings-usb-protection:
-    command: run.sh $SNAP/usr/libexec/gsd-usd-protection
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-gsd-usbprotection
-    restart-delay: 1s
-    plugs: *pluglist
-    slots: *slotlist
-
-  tracker:
-    command: run.sh $SNAP/usr/libexec/tracker-miner-fs-3
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-freedesktop-tracker3-miner-files
-    restart-delay: 1s
-    plugs: *pluglist
-    slots: *slotlist
-
-  a11ybus:
-    command: run.sh /usr/libexec/at-spi-bus-launcher --launch-immediately
-    daemon: dbus
-    daemon-scope: user
-    activates-on:
-      - dbus-a11y-bus
     restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
@@ -345,6 +313,26 @@ plugs:
       - /run/udev/tags/seat
       - /etc/default/im-config
       - /etc/default/locale
+  gtk-3-themes:
+    interface: content
+    target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes
+  gnome-46-2404:
+    interface: content
+    target: $SNAP/gnome-platform
+    default-provider: gnome-46-2404
+  gpu-2404:
+    interface: content
+    target: $SNAP/gpu-2404
+    default-provider: mesa-2404
 
 slots:
   dbus-a11y-bus:
@@ -654,11 +642,24 @@ lint:
     - classic
 
 parts:
+  snapbuildtools:
+    source: https://github.com/sergio-costas/snap-build-tools.git
+    source-depth: 1
+    plugin: nil
+    source-branch: use-snap-list-from-snapcraft-file
+    build-packages:
+      - python3-yaml
+    override-pull: |
+      craftctl default
+      $CRAFT_PART_SRC/install
+
   scripts:
+    after: [ snapbuildtools ]
     plugin: dump
     source: ./scripts
 
   ubuntu-desktop-session:
+    after: [ snapbuildtools ]
     plugin: nil
     build-packages:
       - git
@@ -667,6 +668,7 @@ parts:
       craftctl set version=$(date +%Y%m%d)+git$(git rev-parse --short HEAD)
 
   packages:
+    after: [ snapbuildtools ]
     plugin: nil
     build-packages:
       - libglib2.0-bin
@@ -723,17 +725,23 @@ parts:
       - yaru-theme-icon
     build-environment:
       - LD_LIBRARY_PATH: $CRAFT_PART_INSTALL/usr/lib:$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+    build-snaps: [core24, gtk-common-themes, gnome-46-2404, mesa-2404]
     override-build: |
+      # remove duplicated files
+      $CRAFT_PROJECT_DIR/snapbuildtools/remove_common.py -e usr/libexec usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0
+      # delete empty folders
+      find $CRAFT_PART_INSTALL -type d -empty -delete
+
       # compile schemas
       glib-compile-schemas $CRAFT_PART_INSTALL/usr/share/glib-2.0/schemas
 
       # update pixbuf-loaders cache
-      export CACHE=$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders.cache
-      $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders/* > $CACHE
-      sed -i "s@$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@g" $CACHE
+      #export CACHE=$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders.cache
+      #$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders/* > $CACHE
+      #sed -i "s@$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@g" $CACHE
 
       # update MIME types
-      $CRAFT_PART_INSTALL/usr/bin/update-mime-database $CRAFT_PART_INSTALL/usr/share/mime
+      #$CRAFT_PART_INSTALL/usr/bin/update-mime-database $CRAFT_PART_INSTALL/usr/share/mime
 
       # point to the right path
       sed -i 's@exec /usr/libexec@exec $SNAP/usr/libexec@g' $CRAFT_PART_INSTALL/usr/bin/gnome-session
@@ -751,5 +759,10 @@ parts:
       EOF
       chmod a+x $CRAFT_PART_INSTALL/usr/libexec/gsd-xsettings
 
+      # copy gio utils into usr/libexec
+      cp $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/glib-2.0/gio* $CRAFT_PART_INSTALL/usr/libexec/
+
+      # delete the doc folders
+      rm -rf $CRAFT_PART_INSTALL/usr/share/doc
       craftctl default
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ environment:
   XDG_CONFIG_HOME: $SNAP_USER_COMMON/.config
   XDG_DATA_HOME: $SNAP_USER_COMMON/.local/share
   XDG_STATE_HOME: $SNAP_USER_COMMON/.local/state
-  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:$SNAP/usr/lib/gnome-settings-daemon-46:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libunity:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-3.0
+  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:$SNAP/usr/lib/gnome-settings-daemon-46:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libunity:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30
   GSETTINGS_SCHEMA_DIR: $SNAP/usr/share/glib-2.0/schemas${GSETTINGS_SCHEMA_DIR:+:$GSETTINGS_SCHEMA_DIR}
   GI_TYPELIB_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/gnome-shell/girepository-1.0:$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}
 
@@ -53,7 +53,17 @@ layout:
     symlink: $SNAP/usr/share/tracker3
   /usr/share/tracker3-miners:
     symlink: $SNAP/usr/share/tracker3-miners
+  /usr/share/libwacom:
+    symlink: $SNAP/usr/share/libwacom
+  /usr/share/nautilus:
+    symlink: $SNAP/usr/share/nautilus
+  /usr/share/gtk-3.0:
+    symlink: $SNAP:/usr/share/gtk-3.0
+  /usr/share/gtk-4.0:
+    symlink: $SNAP:/usr/share/gtk-4.0
 
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0:
     symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri:
@@ -64,7 +74,6 @@ layout:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/samba:
     symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/samba
-
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0:
     symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-3.0:
@@ -153,7 +162,7 @@ apps:
     passthrough:
       daemon-scope: user
     activates-on:
-      - dbus-gnome-shell-screencast
+      - dbus-gnome-mutter-screencast
     restart-delay: 1s
     plugs: *pluglist
 
@@ -177,13 +186,13 @@ apps:
     restart-delay: 1s
     plugs: *pluglist
 
-  #xdg-desktop-portal-gtk:
-  #  command: run.sh /usr/libexec/xdg-desktop-portal-gtk
-  #  daemon: dbus
-  #  daemon-scope: user
-  #  activates-on:
-  #    - dbus-freedesktop-impl-portal-gtk
-  #  restart-delay: 1s
+  xdg-desktop-portal-gtk:
+    command: run.sh /usr/libexec/xdg-desktop-portal-gtk
+    daemon: dbus
+    daemon-scope: user
+    activates-on:
+      - dbus-freedesktop-impl-portal-gtk
+    restart-delay: 1s
 
   ibus-service:
     command: run.sh $SNAP/usr/bin/ibus-daemon --panel disable
@@ -453,6 +462,14 @@ slots:
     interface: dbus
     bus: session
     name: com.canonical.Unity
+  dbus-desktop-icons:
+    interface: dbus
+    bus: session
+    name: com.rastersoft.ding
+  dbus-desktop-icons-extension:
+    interface: dbus
+    bus: session
+    name: com.rastersoft.dingextension
   dbus-freedesktop-tracker3-miner-files:
     interface: dbus
     bus: session
@@ -465,6 +482,95 @@ slots:
     interface: dbus
     bus: session
     name: org.freedesktop.impl.portal.desktop.gtk
+  dbus-gnome-mutter-displayconfig:
+    interface: dbus
+    bus: session
+    name: org.gnome.Mutter.DisplayConfig
+  dbus-gnome-mutter-idlemonitor:
+    interface: dbus
+    bus: session
+    name: org.gnome.Mutter.IdleMonitor
+  dbus-gnome-mutter-inputcapture:
+    interface: dbus
+    bus: session
+    name: org.gnome.Mutter.InputCapture
+  dbus-gnome-mutter-inputmapping:
+    interface: dbus
+    bus: session
+    name: org.gnome.Mutter.InputMapping
+  dbus-gnome-mutter-remotedesktop:
+    interface: dbus
+    bus: session
+    name: org.gnome.Mutter.RemoteDesktop
+  dbus-gnome-mutter-screencast:
+    interface: dbus
+    bus: session
+    name: org.gnome.Mutter.ScreenCast
+  dbus-gnome-mutter-service-channel:
+    interface: dbus
+    bus: session
+    name: org.gnome.Mutter.ServiceChannel
+  dbus-gsd-color:
+    interface: dbus
+    bus: session
+    name: org.gnome.SettingsDaemon.Color
+  dbus-gsd-power:
+    interface: dbus
+    bus: session
+    name: org.gnome.SettingsDaemon.Power
+  dbus-gsd-rfkill:
+    interface: dbus
+    bus: session
+    name: org.gnome.SettingsDaemon.Rfkill
+  dbus-gsd-wacom:
+    interface: dbus
+    bus: session
+    name: org.gnome.SettingsDaemon.Wacom
+  dbus-gnome-shell:
+    interface: dbus
+    bus: session
+    name: org.gnome.Shell
+  dbus-gnome-shell-audio:
+    interface: dbus
+    bus: session
+    name: org.gnome.Shell.AudioDeviceSelection
+  dbus-gnome-shell-introspect:
+    interface: dbus
+    bus: session
+    name: org.gnome.Shell.Introspect
+  dbus-gnome-shell-portal:
+    interface: dbus
+    bus: session
+    name: org.gnome.Shell.Portal
+  dbus-gnome-shell-screenshield:
+    interface: dbus
+    bus: session
+    name: org.gnome.Shell.ScreenShield
+  dbus-gnome-shell-screenshot:
+    interface: dbus
+    bus: session
+    name: org.gnome.Shell.Screenshot
+  dbus-gnome-shell-wacom:
+    interface: dbus
+    bus: session
+    name: org.gnome.Shell.Wacom.PadOsd
+  dbus-gnome-keyring-sysprompter:
+    interface: dbus
+    bus: session
+    name: org.gnome.keyring.SystemPrompter
+  dbus-gtk-mountoperationhandler:
+    interface: dbus
+    bus: session
+    name: org.gtk.MountOperationHandler
+  dbus-gtk-notifications:
+    interface: dbus
+    bus: session
+    name: org.gtk.Notifications
+  dbus-kde-statusnotifier:
+    interface: dbus
+    bus: session
+    name: org.kde.StatusNotifierWatcher
+
   dbus-freedesktop-screensaver:
     interface: dbus
     bus: session
@@ -485,34 +591,10 @@ slots:
     interface: dbus
     bus: session
     name: org.gnome.keyring
-  dbus-gnome-keyring-sysprompter:
-    interface: dbus
-    bus: session
-    name: org.gnome.keyring.SystemPrompter
   dbus-gnome-magnifier:
     interface: dbus
     bus: session
     name: org.gnome.Magnifier
-  dbus-gnome-mutter-displayconfig:
-    interface: dbus
-    bus: session
-    name: org.gnome.Mutter.DisplayConfig
-  dbus-gnome-mutter-idlemonitor:
-    interface: dbus
-    bus: session
-    name: org.gnome.Mutter.IdleMonitor
-  dbus-gnome-mutter-remotedesktop:
-    interface: dbus
-    bus: session
-    name: org.gnome.Mutter.RemoteDesktop
-  dbus-gnome-mutter-screencast:
-    interface: dbus
-    bus: session
-    name: org.gnome.Mutter.ScreenCast
-  #dbus-gnome-mutter-service-channel:
-  #  interface: dbus
-  #  bus: session
-  #  name: org.gnome.Mutter.ServiceChannel
   dbus-gnome-panel:
     interface: dbus
     bus: session
@@ -537,10 +619,6 @@ slots:
     interface: dbus
     bus: session
     name: org.gnome.SettingsDaemon.A11ySettings
-  dbus-gsd-color:
-    interface: dbus
-    bus: session
-    name: org.gnome.SettingsDaemon.Color
   dbus-gsd-datetime:
     interface: dbus
     bus: session
@@ -557,18 +635,10 @@ slots:
     interface: dbus
     bus: session
     name: org.gnome.SettingsDaemon.MediaKeys
-  dbus-gsd-power:
-    interface: dbus
-    bus: session
-    name: org.gnome.SettingsDaemon.Power
   dbus-gsd-printnotifications:
     interface: dbus
     bus: session
     name: org.gnome.SettingsDaemon.PrintNotifications
-  dbus-gsd-rfkill:
-    interface: dbus
-    bus: session
-    name: org.gnome.SettingsDaemon.Rfkill
   dbus-gsd-screensaverproxy:
     interface: dbus
     bus: session
@@ -589,10 +659,6 @@ slots:
     interface: dbus
     bus: session
     name: org.gnome.SettingsDaemon.UsbProtection
-  dbus-gsd-wacom:
-    interface: dbus
-    bus: session
-    name: org.gnome.SettingsDaemon.Wacom
   dbus-gsd-wwan:
     interface: dbus
     bus: session
@@ -605,34 +671,6 @@ slots:
     interface: dbus
     bus: session
     name: org.gnome.Nautilus
-  dbus-gnome-shell:
-    interface: dbus
-    bus: session
-    name: org.gnome.Shell
-  dbus-gnome-shell-audio:
-    interface: dbus
-    bus: session
-    name: org.gnome.Shell.AudioDeviceSelection
-  dbus-gnome-shell-introspect:
-    interface: dbus
-    bus: session
-    name: org.gnome.Shell.Introspect
-  dbus-gnome-shell-portal:
-    interface: dbus
-    bus: session
-    name: org.gnome.Shell.Portal
-  dbus-gnome-shell-screencast:
-    interface: dbus
-    bus: session
-    name: org.gnome.Shell.Screencast
-  dbus-gnome-shell-screenshot:
-    interface: dbus
-    bus: session
-    name: org.gnome.Shell.Screenshot
-  dbus-gnome-shell-wacom:
-    interface: dbus
-    bus: session
-    name: org.gnome.Shell.Wacom.PadOsd
   dbus-gnome-settings:
     interface: dbus
     bus: session
@@ -641,30 +679,10 @@ slots:
     interface: dbus
     bus: session
     name: org.gnome.Terminal
-  dbus-gtk-mountoperationhandler:
-    interface: dbus
-    bus: session
-    name: org.gtk.MountOperationHandler
-  dbus-gtk-notifications:
-    interface: dbus
-    bus: session
-    name: org.gtk.Notifications
   dbus-gtk-settings:
     interface: dbus
     bus: session
     name: org.gtk.Settings
-  dbus-kde-statusnotifier:
-    interface: dbus
-    bus: session
-    name: org.kde.StatusNotifierWatcher
-  dbus-desktop-icons:
-    interface: dbus
-    bus: session
-    name: com.rastersoft.ding
-  dbus-desktop-icons-extension:
-    interface: dbus
-    bus: session
-    name: com.rastersoft.dingextension
   dbus-portal:
     interface: dbus
     name: org.freedesktop.impl.portal.PermissionStore

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,9 +58,11 @@ layout:
   /usr/share/nautilus:
     symlink: $SNAP/usr/share/nautilus
   /usr/share/gtk-3.0:
-    symlink: $SNAP:/usr/share/gtk-3.0
+    symlink: $SNAP/usr/share/gtk-3.0
   /usr/share/gtk-4.0:
-    symlink: $SNAP:/usr/share/gtk-4.0
+    symlink: $SNAP/usr/share/gtk-4.0
+  /usr/share/defaults:
+    symlink: $SNAP/usr/share/defaults
 
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30:
     symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30
@@ -159,32 +161,35 @@ apps:
   screencast-service:
     command: run.sh $SNAP/usr/bin/gjs -m /usr/share/gnome-shell/org.gnome.Shell.Screencast
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gnome-mutter-screencast
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gnome-mutter-screencast
 
   nautilus-service:
     command: run.sh $SNAP/usr/bin/nautilus --gapplication-service
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gnome-nautilus
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gnome-nautilus
 
   xdg-desktop-portal-gnome:
     command: run.sh $SNAP/usr/libexec/xdg-desktop-portal-gnome
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-freedesktop-impl-portal-gnome
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-freedesktop-impl-portal-gnome
 
   xdg-desktop-portal-gtk:
     command: run.sh /usr/libexec/xdg-desktop-portal-gtk
@@ -193,246 +198,283 @@ apps:
     activates-on:
       - dbus-freedesktop-impl-portal-gtk
     restart-delay: 1s
+    slots:
+      - dbus-freedesktop-impl-portal-gtk
 
   ibus-service:
     command: run.sh $SNAP/usr/bin/ibus-daemon --panel disable
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-ibus
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-ibus
 
   ibus-gtk3-service:
     command: run.sh $SNAP/usr/libexec/ibus-extension-gtk3
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-ibus-gtk3
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-ibus-gtk3
 
   ibus-portal-service:
     command: run.sh $SNAP/usr/libexec/ibus-portal
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-ibus-portal
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-ibus-portal
 
   colord:
     command: run.sh $SNAP/usr/libexec/colord-session
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-colord
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-colord
 
   calendar-server:
     command: run.sh $SNAP/usr/libexec/gnome-shell-calendar-server
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gnome-shell-calendar-server
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gnome-shell-calendar-server
 
   gtk-settings:
     command: run.sh $SNAP/usr/libexec/gsd-xsettings
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gtk-settings
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gtk-settings
 
   gnome-settings:
     command: run.sh $SNAP/usr/bin/gnome-control-center
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gnome-settings
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gnome-settings
 
   gnome-settings-a11y:
     command: run.sh $SNAP/usr/libexec/gsd-a11y-settings
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-a11ysettings
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-a11ysettings
 
   gnome-settings-color:
     command: run.sh $SNAP/usr/libexec/gsd-color
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-color
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-color
 
   gnome-settings-datetime:
     command: run.sh $SNAP/usr/libexec/gsd-datetime
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-datetime
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-datetime
 
   gnome-settings-housekeeping:
     command: run.sh $SNAP/usr/libexec/gsd-housekeeping
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-housekeeping
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-housekeeping
 
   gnome-settings-keyboard:
     command: run.sh $SNAP/usr/libexec/gsd-keyboard
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-keyboard
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-keyboard
 
   gnome-settings-media-keys:
     command: run.sh $SNAP/usr/libexec/gsd-media-keys
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-mediakeys
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-mediakeys
 
   gnome-settings-power:
     command: run.sh $SNAP/usr/libexec/gsd-power
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-power
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-power
 
   gnome-settings-print-notifications:
     command: run.sh $SNAP/usr/libexec/gsd-print-notifications
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-printnotifications
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-printnotifications
 
   gnome-settings-rfkill:
     command: run.sh $SNAP/usr/libexec/gsd-rfkill
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-rfkill
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-rfkill
 
   gnome-settings-screensaver-proxy:
     command: run.sh $SNAP/usr/libexec/gsd-screensaver-proxy
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-screensaverproxy
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-screensaverproxy
 
   gnome-settings-sharing:
     command: run.sh $SNAP/usr/libexec/gsd-sharing
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-sharing
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-sharing
 
   gnome-settings-smartcard:
     command: run.sh $SNAP/usr/libexec/gsd-smartcard
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-smartcard
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-smartcard
 
   gnome-settings-sound:
     command: run.sh $SNAP/usr/libexec/gsd-sound
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-sound
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-sound
 
   gnome-settings-usb-protection:
     command: run.sh $SNAP/usr/libexec/gsd-usd-protection
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-usbprotection
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-usbprotection
 
   gnome-settings-wacom:
     command: run.sh $SNAP/usr/libexec/gsd-wacom
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-wacom
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-wacom
 
   gnome-settings-xsettings:
     command: run.sh $SNAP/usr/libexec/gsd-xsettings
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-gsd-xsettings
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-gsd-xsettings
 
   tracker:
     command: run.sh $SNAP/usr/libexec/tracker-miner-fs-3
     daemon: dbus
-    passthrough:
-      daemon-scope: user
+    daemon-scope: user
     activates-on:
       - dbus-freedesktop-tracker3-miner-files
     restart-delay: 1s
     plugs: *pluglist
+    slots:
+      - dbus-freedesktop-tracker3-miner-files
+
+  a11ybus:
+    command: run.sh /usr/libexec/at-spi-bus-launcher --launch-immediately
+    daemon: dbus
+    daemon-scope: user
+    activates-on:
+      - dbus-a11y-bus
+    restart-delay: 1s
+    plugs: *pluglist
+    slots:
+      - dbus-a11y-bus
 
 plugs:
   dot-local-share-nautilus:
@@ -458,6 +500,10 @@ plugs:
       - /etc/default/locale
 
 slots:
+  dbus-a11y-bus:
+    interface: dbus
+    bus: session
+    name: org.a11y.Bus
   dbus-canonical-unity:
     interface: dbus
     bus: session
@@ -470,6 +516,10 @@ slots:
     interface: dbus
     bus: session
     name: com.rastersoft.dingextension
+  dbus-desktop-icons-test:
+    interface: dbus
+    bus: session
+    name: com.rastersoft.dingtest
   dbus-freedesktop-tracker3-miner-files:
     interface: dbus
     bus: session
@@ -727,6 +777,7 @@ parts:
       - libglib2.0-bin
     stage-packages:
       - alsa-ucm-conf
+      - at-spi2-core
       - fonts-ubuntu
       - gir1.2-clutter-1.0
       - gir1.2-dbusmenu-glib-0.4

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -223,16 +223,6 @@ apps:
     plugs: *pluglist
     slots: *slotlist
 
-  xdg-desktop-portal-gnome:
-    command: run.sh $SNAP/usr/libexec/xdg-desktop-portal-gnome
-    plugs: *pluglist
-    slots: *slotlist
-
-  xdg-desktop-portal-gtk:
-    command: run.sh $SNAP/usr/libexec/xdg-desktop-portal-gtk
-    plugs: *pluglist
-    slots: *slotlist
-
   ibus-service:
     command: run.sh $SNAP/usr/bin/ibus-daemon --panel disable
     daemon: dbus
@@ -283,11 +273,6 @@ apps:
     plugs: *pluglist
     slots: *slotlist
 
-  gtk-settings:
-    command: run.sh $SNAP/usr/libexec/gsd-xsettings
-    plugs: *pluglist
-    slots: *slotlist
-
   gnome-settings:
     command: run.sh $SNAP/usr/bin/gnome-control-center
     daemon: dbus
@@ -295,11 +280,6 @@ apps:
     activates-on:
       - dbus-gnome-settings
     restart-delay: 1s
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings-a11y:
-    command: run.sh $SNAP/usr/libexec/gsd-a11y-settings
     plugs: *pluglist
     slots: *slotlist
 
@@ -313,61 +293,6 @@ apps:
     plugs: *pluglist
     slots: *slotlist
 
-  gnome-settings-datetime:
-    command: run.sh $SNAP/usr/libexec/gsd-datetime
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings-housekeeping:
-    command: run.sh $SNAP/usr/libexec/gsd-housekeeping
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings-keyboard:
-    command: run.sh $SNAP/usr/libexec/gsd-keyboard
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings-media-keys:
-    command: run.sh $SNAP/usr/libexec/gsd-media-keys
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings-power:
-    command: run.sh $SNAP/usr/libexec/gsd-power
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings-print-notifications:
-    command: run.sh $SNAP/usr/libexec/gsd-print-notifications
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings-rfkill:
-    command: run.sh $SNAP/usr/libexec/gsd-rfkill
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings-screensaver-proxy:
-    command: run.sh $SNAP/usr/libexec/gsd-screensaver-proxy
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings-sharing:
-    command: run.sh $SNAP/usr/libexec/gsd-sharing
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings-smartcard:
-    command: run.sh $SNAP/usr/libexec/gsd-smartcard
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings-sound:
-    command: run.sh $SNAP/usr/libexec/gsd-sound
-    plugs: *pluglist
-    slots: *slotlist
-
   gnome-settings-usb-protection:
     command: run.sh $SNAP/usr/libexec/gsd-usd-protection
     daemon: dbus
@@ -375,16 +300,6 @@ apps:
     activates-on:
       - dbus-gsd-usbprotection
     restart-delay: 1s
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings-wacom:
-    command: run.sh $SNAP/usr/libexec/gsd-wacom
-    plugs: *pluglist
-    slots: *slotlist
-
-  gnome-settings-xsettings:
-    command: run.sh $SNAP/usr/libexec/gsd-xsettings
     plugs: *pluglist
     slots: *slotlist
 
@@ -835,16 +750,6 @@ parts:
       exec /usr/libexec/gsd-xsettings.real "$@"
       EOF
       chmod a+x $CRAFT_PART_INSTALL/usr/libexec/gsd-xsettings
-
-      # remove dependencies on ubuntu session (temporary)
-      rm -f $CRAFT_PART_INSTALL/usr/share/gnome-session/sessions/ubuntu.session
-
-      cat <<\EOF > $CRAFT_PART_INSTALL/usr/share/gnome-session/sessions/ubuntu.session
-      [GNOME Session]
-      Name=Ubuntu
-      # Must be in sync with gnome-session@ubuntu.target.d/ubuntu.session.conf drop-in
-      RequiredComponents=org.gnome.Shell;org.gnome.SettingsDaemon.A11ySettings;org.gnome.SettingsDaemon.Datetime;org.gnome.SettingsDaemon.Housekeeping;org.gnome.SettingsDaemon.Keyboard;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.PrintNotifications;org.gnome.SettingsDaemon.Rfkill;org.gnome.SettingsDaemon.ScreensaverProxy;org.gnome.SettingsDaemon.Sharing;org.gnome.SettingsDaemon.Smartcard;org.gnome.SettingsDaemon.Sound;org.gnome.SettingsDaemon.Wacom;org.gnome.SettingsDaemon.XSettings;
-      EOF
 
       craftctl default
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,13 +22,16 @@ environment:
   XDG_CONFIG_HOME: $SNAP_USER_COMMON/.config
   XDG_DATA_HOME: $SNAP_USER_COMMON/.local/share
   XDG_STATE_HOME: $SNAP_USER_COMMON/.local/state
-  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libunity:$SNAP/gpu-2404/usr/lib:$SNAP/gpu-2404/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/lib:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:$SNAP/usr/lib/gnome-settings-daemon-46:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gvfs
+  LD_LIBRARY_PATH: $SNAP/gnome-platform/usr/lib:${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libunity:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/lib:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:$SNAP/usr/lib/gnome-settings-daemon-46:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-3.0:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gvfs
   GSETTINGS_SCHEMA_DIR: $SNAP/gnome-platform/usr/share/glib-2.0/schemas:$SNAP/usr/share/glib-2.0/schemas${GSETTINGS_SCHEMA_DIR:+:$GSETTINGS_SCHEMA_DIR}
-  GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$SNAP/gnome-platform/usr/lib/girepository-1.0:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/gnome-shell/girepository-1.0:$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}
+  GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$SNAP/gnome-platform/usr/lib/girepository-1.0:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/gnome-shell/girepository-1.0:$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}
   SNAP_DESKTOP_RUNTIME: $SNAP/gnome-platform
   PATH: /bin:/usr/bin:$SNAP/bin:$SNAP/usr/bin:$SNAP/usr/libexec:$SNAP/gnome-platform/bin:$SNAP/gnome-platform/usr/bin:$SNAP/gnome-platform/usr/libexec${PATH:+:$PATH}
+  XDG_DATA_DIRS: /usr/share:$SNAP/usr/share:$SNAP/gnome-platform/usr/share:$SNAP/data-dir:/var/lib/snapd/desktop${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}
 
 layout:
+  /usr/share/hwdata:
+    symlink: $SNAP/usr/share/hwdata
   /usr/share/libinput:
     symlink: $SNAP/gnome-platform/usr/share/libinput
   /usr/share/xml/iso-codes:
@@ -38,13 +41,16 @@ layout:
   /usr/share/applications:
     bind: $SNAP/usr/share/applications
   /usr/share/glvnd:
-    symlink: $SNAP/gpu-2404/usr/share/glvnd
+    symlink: $SNAP/usr/share/glvnd
+#    symlink: $SNAP/gpu-2404/usr/share/glvnd
   /usr/share/X11:
     symlink: $SNAP/gnome-platform/usr/share/X11
   /usr/share/egl:
-    symlink: $SNAP/gpu-2404/usr/share/egl
+    symlink: $SNAP/usr/share/egl
+    #symlink: $SNAP/gpu-2404/usr/share/egl
   /usr/share/vulkan:
-    symlink: $SNAP/gpu-2404/usr/share/vulkan
+    symlink: $SNAP/usr/share/vulkan
+    #symlink: $SNAP/gpu-2404/usr/share/vulkan
   /usr/share/fonts:
     bind: $SNAP/gnome-platform/usr/share/fonts
   /usr/share/fontconfig:
@@ -60,7 +66,7 @@ layout:
   /usr/share/tracker3-miners:
     symlink: $SNAP/usr/share/tracker3-miners
   /usr/share/libwacom:
-    symlink: $SNAP/gnome-platform/usr/share/libwacom
+    symlink: $SNAP/usr/share/libwacom
   /usr/share/nautilus:
     symlink: $SNAP/usr/share/nautilus
   /usr/share/gtk-3.0:
@@ -71,6 +77,9 @@ layout:
     symlink: $SNAP/gnome-platform/usr/share/defaults
   /usr/share/xdg-desktop-portal:
     symlink: $SNAP/usr/share/xdg-desktop-portal
+
+  /usr/share/libgnomekbd:
+    symlink: $SNAP/usr/share/libgnomekbd
 
   /usr/share/dbus-1/interfaces/org.freedesktop.Accounts.User.xml:
     symlink: $SNAP/usr/share/dbus-1/interfaces/org.freedesktop.Accounts.User.xml
@@ -126,9 +135,11 @@ layout:
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0:
     symlink: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri:
-    symlink: $SNAP/gpu-2404/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri
+    #symlink: $SNAP/gpu-2404/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/vdpau:
-    symlink: $SNAP/gpu-2404/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/vdpau
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/vdpau
+    #symlink: $SNAP/gpu-2404/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/vdpau
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4:
     symlink: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0:
@@ -167,6 +178,8 @@ layout:
     symlink: $SNAP/gnome-platform/etc/xdg/user-dirs.conf
   /etc/xdg/xdg/user-dirs.defaults:
     symlink: $SNAP/gnome-platform/etc/xdg/user-dirs.defaults
+  /etc/geoclue:
+    bind: $SNAP/etc/geoclue
 
   /usr/bin/Xwayland:
     symlink: $SNAP/usr/bin/Xwayland
@@ -190,7 +203,7 @@ layout:
   /usr/share/libdrm:
     bind: $SNAP/gpu-2404/libdrm
   /usr/share/drirc.d:
-    symlink: $SNAP/gpu-2404/drirc.d
+    symlink: $SNAP/gpu-2040/drirc.d
 
 assumes:
 - snapd2.43
@@ -212,6 +225,7 @@ apps:
       - dbus-ibus-gtk3
       - dbus-ibus-portal
       - dbus-colord
+      - dbus-geoclue
       - dbus-gnome-shell-calendar-server
       - dbus-gtk-settings
       - dbus-gnome-settings
@@ -345,13 +359,12 @@ apps:
     plugs: *pluglist
     slots: *slotlist
 
-  screensaver:
-    command: run.sh gjs -m /usr/share/gnome-shell/org.gnome.ScreenSaver
+  geoclue:
+    command: run.sh /usr/libexec/geoclue
     daemon: dbus
-    passthrough:
-      daemon-scope: user
     activates-on:
-      - dbus-gnome-screensaver
+      - dbus-geoclue
+    restart-delay: 1s
     plugs: *pluglist
     slots: *slotlist
 
@@ -699,6 +712,10 @@ slots:
     interface: dbus
     name: org.freedesktop.ColorHelper
     bus: session
+  dbus-geoclue:
+    interface: dbus
+    name: org.freedesktop.GeoClue2
+    bus: system
 
 lint:
   ignore:
@@ -709,7 +726,7 @@ parts:
     source: https://github.com/sergio-costas/snap-build-tools.git
     source-depth: 1
     plugin: nil
-    source-branch: use-snap-list-from-snapcraft-file
+    source-branch: select-folders-to-clean
     build-packages:
       - python3-yaml
     override-pull: |
@@ -735,6 +752,7 @@ parts:
     plugin: nil
     build-packages:
       - libglib2.0-bin
+      - gtk-update-icon-cache
     stage-packages:
       - alsa-ucm-conf
       - at-spi2-core
@@ -755,6 +773,7 @@ parts:
       - gnome-shell-extension-ubuntu-dock
       - gnome-shell-extension-ubuntu-tiling-assistant
       - gsound-tools
+      - hwdata
       - ibus
       - im-config
       - inotify-tools
@@ -792,13 +811,18 @@ parts:
       - core24
       - gtk-common-themes
       - gnome-46-2404
-      - mesa-2404
+      #- mesa-2404
     override-build: |
 
       # remove duplicated files
-      $CRAFT_PROJECT_DIR/snapbuildtools/remove_common.py -e usr/libexec usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0
-      # delete empty folders
-      find $CRAFT_PART_INSTALL -type d -empty -delete
+      $CRAFT_PROJECT_DIR/snapbuildtools/remove_common.py -e usr/libexec usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0/gio\*
+
+      # recreate icons cache
+      for ICONPATH in $CRAFT_PART_INSTALL/usr/share/icons/*; do
+        if [ -f ${ICONPATH}/index.theme ]; then
+          gtk-update-icon-cache -f $ICONPATH
+        fi
+      done
 
       # compile schemas
       glib-compile-schemas $CRAFT_PART_INSTALL/usr/share/glib-2.0/schemas
@@ -822,8 +846,9 @@ parts:
       # copy gio utils into usr/libexec
       cp $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/glib-2.0/gio* $CRAFT_PART_INSTALL/usr/libexec/
 
-      # delete the doc folders
+      # delete the doc and help folders
       rm -rf $CRAFT_PART_INSTALL/usr/share/doc
+      rm -rf $CRAFT_PART_INSTALL/usr/share/help
       craftctl default
 
   command-chain:


### PR DESCRIPTION
These are the changes required to have a stand-alone gnome-shell session. This requires https://github.com/canonical/core-base-desktop/pull/76 as base to work, but not as a dependency itself, but just to remove unneeded things from the core-base running in the system (the base for this is core-24).

This is similar to #39, but it still doesn't work fine due to problems with libraries (it tries to remove duplicated files also from `gnome-46-2404` and `mesa-2404`, but there are still some problems to be fixed).