### PR TITLE
Stand alone ubuntu session

### DIFF
--- a/fix-gnome-modules.py
+++ b/fix-gnome-modules.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import sys
+
+filename = sys.argv[1]
+
+with open(filename, "r") as inputfile:
+    data = inputfile.read()
+
+if filename.endswith(".desktop"):
+    data = data.replace("Exec=/usr", "Exec=/snap/ubuntu-desktop-session/current/usr")
+else:
+    data = data.replace("'/usr", "'/snap/ubuntu-desktop-session/current/usr")
+
+with open(filename, "w") as outputfile:
+    outputfile.write(data)

--- a/scripts/run-session.sh
+++ b/scripts/run-session.sh
@@ -16,7 +16,6 @@ mkdir -p --mode=700 $XDG_RUNTIME_DIR
 USERPATH=/run/user/`id -u`
 
 export PULSE_SERVER=unix:$USERPATH/pulse/native
-#export WAYLAND_DISPLAY=$USERPATH/wayland-0
 export GNOME_SHELL_SESSION_MODE=ubuntu
 export PIPEWIRE_RUNTIME_DIR=$USERPATH
 

--- a/scripts/run-session.sh
+++ b/scripts/run-session.sh
@@ -5,6 +5,13 @@ if command -v xdg-user-dirs-update >/dev/null; then
   xdg-user-dirs-update
 fi
 
+# These must be deleted to ensure that another user can
+# launch a session from GDM. Not doing it (or doing it from
+# outside the snap) will prevent login with a different user
+# than the first one that logged in, until the system is reboot.
+rm -rf /tmp/.X11-unix
+rm -rf /tmp/.ICE-unix
+
 # Ensure socket directories exist and have the right permissions
 mkdir -p /tmp/.X11-unix /tmp/.ICE-unix
 chmod 01777 /tmp/.X11-unix /tmp/.ICE-unix
@@ -16,7 +23,7 @@ mkdir -p --mode=700 $XDG_RUNTIME_DIR
 USERPATH=/run/user/`id -u`
 
 export PULSE_SERVER=unix:$USERPATH/pulse/native
-export WAYLAND_DISPLAY=$USERPATH/wayland-0
+#export WAYLAND_DISPLAY=$USERPATH/wayland-0
 export GNOME_SHELL_SESSION_MODE=ubuntu
 export PIPEWIRE_RUNTIME_DIR=$USERPATH
 
@@ -25,10 +32,4 @@ if ! grep "^snap$" $HOME/.hidden 2>&1 > /dev/null; then
 fi
 
 #exec $SNAP/usr/bin/gnome-shell --display-server --wayland
-$SNAP/usr/bin/gnome-session --builtin --session=ubuntu
-# These must be deleted to ensure that another user can
-# launch a session from GDM. Not doing it (or doing it from
-# outside the snap) will prevent login with a different user
-# than the first one that logged in, until the system is reboot.
-rm -rf /tmp/.X11-unix
-rm -rf /tmp/.ICE-unix
+exec $SNAP/usr/bin/gnome-session --builtin --session=ubuntu

--- a/scripts/run-session.sh
+++ b/scripts/run-session.sh
@@ -10,14 +10,25 @@ mkdir -p /tmp/.X11-unix /tmp/.ICE-unix
 chmod 01777 /tmp/.X11-unix /tmp/.ICE-unix
 
 # Create the runtime directory
+echo creating the runtime directory $XDG_RUNTIME_DIR
 mkdir -p --mode=700 $XDG_RUNTIME_DIR
 
-export PULSE_SERVER=unix:/run/user/`id -u`/pulse/native
+USERPATH=/run/user/`id -u`
+
+export PULSE_SERVER=unix:$USERPATH/pulse/native
+export WAYLAND_DISPLAY=$USERPATH/wayland-0
 export GNOME_SHELL_SESSION_MODE=ubuntu
-export XDG_CURRENT_DESKTOP=ubuntu:GNOME
+export PIPEWIRE_RUNTIME_DIR=$USERPATH
 
 if ! grep "^snap$" $HOME/.hidden 2>&1 > /dev/null; then
   echo "snap" >> $HOME/.hidden
 fi
 
-exec /usr/bin/gnome-session --builtin --session=ubuntu
+#exec $SNAP/usr/bin/gnome-shell --display-server --wayland
+$SNAP/usr/bin/gnome-session --builtin --session=ubuntu
+# These must be deleted to ensure that another user can
+# launch a session from GDM. Not doing it (or doing it from
+# outside the snap) will prevent login with a different user
+# than the first one that logged in, until the system is reboot.
+rm -rf /tmp/.X11-unix
+rm -rf /tmp/.ICE-unix

--- a/scripts/run-session.sh
+++ b/scripts/run-session.sh
@@ -5,13 +5,6 @@ if command -v xdg-user-dirs-update >/dev/null; then
   xdg-user-dirs-update
 fi
 
-# These must be deleted to ensure that another user can
-# launch a session from GDM. Not doing it (or doing it from
-# outside the snap) will prevent login with a different user
-# than the first one that logged in, until the system is reboot.
-rm -rf /tmp/.X11-unix
-rm -rf /tmp/.ICE-unix
-
 # Ensure socket directories exist and have the right permissions
 mkdir -p /tmp/.X11-unix /tmp/.ICE-unix
 chmod 01777 /tmp/.X11-unix /tmp/.ICE-unix
@@ -32,4 +25,10 @@ if ! grep "^snap$" $HOME/.hidden 2>&1 > /dev/null; then
 fi
 
 #exec $SNAP/usr/bin/gnome-shell --display-server --wayland
-exec $SNAP/usr/bin/gnome-session --builtin --session=ubuntu
+$SNAP/usr/bin/gnome-session --builtin --session=ubuntu
+# These must be deleted to ensure that another user can
+# launch a session from GDM. Not doing it (or doing it from
+# outside the snap) will prevent login with a different user
+# than the first one that logged in, until the system is reboot.
+rm -rf /tmp/.X11-unix
+rm -rf /tmp/.ICE-unix

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 USERPATH=/run/user/`id -u`
 export PULSE_SERVER=unix:$USERPATH/pulse/native
-#export WAYLAND_DISPLAY=$USERPATH/wayland-0
 export PIPEWIRE_RUNTIME_DIR=$USERPATH
 exec "$@"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
-export PULSE_SERVER=unix:/run/user/`id -u`/pulse/native
+USERPATH=/run/user/`id -u`
+export PULSE_SERVER=unix:$USERPATH/pulse/native
+export WAYLAND_DISPLAY=$USERPATH/wayland-0
+export PIPEWIRE_RUNTIME_DIR=$USERPATH
 exec "$@"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 USERPATH=/run/user/`id -u`
 export PULSE_SERVER=unix:$USERPATH/pulse/native
-export WAYLAND_DISPLAY=$USERPATH/wayland-0
+#export WAYLAND_DISPLAY=$USERPATH/wayland-0
 export PIPEWIRE_RUNTIME_DIR=$USERPATH
 exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,8 +113,6 @@ layout:
     bind: $SNAP/etc/gnome
   /etc/mime.types:
     bind-file: $SNAP/etc/mime.types
-  /etc/profile.d/gnome-session_gnomerc.sh:
-    bind-file: $SNAP/etc/profile.d/gnome-session_gnomerc.sh
   /etc/xdg:
     bind: $SNAP/etc/xdg
   /etc/profile.d/xdg-dirs-desktop-session.sh:
@@ -138,8 +136,6 @@ layout:
     symlink: $SNAP/usr/bin/xdg-user-dir
   /usr/bin/xdg-user-dirs-update:
     symlink: $SNAP/usr/bin/xdg-user-dirs-update
-  /usr/bin/gnome-session-quit:
-    bind-file: $SNAP/usr/bin/gnome-session-quit
   /usr/bin/gnome-terminal.real:
     symlink: $SNAP/usr/bin/gnome-terminal.real
 
@@ -160,53 +156,18 @@ apps:
       - dbus-gnome-keyring
       - dbus-gnome-keyring-sysprompter
       - dbus-gnome-magnifier
-      - dbus-gnome-mutter-displayconfig
-      - dbus-gnome-mutter-idlemonitor
-      - dbus-gnome-mutter-input-capturer
-      - dbus-gnome-mutter-input-mapping
-      - dbus-gnome-mutter-remotedesktop
-      - dbus-gnome-mutter-screencast
-      - dbus-gnome-mutter-service-channel
-      - dbus-gnome-mutter-x11
       - dbus-gnome-panel
       - dbus-gnome-screensaver
       - dbus-gnome-sessionmanager
-      - dbus-gsd
-      - dbus-gsd-a11ysettings
-      - dbus-gsd-color
-      - dbus-gsd-datetime
-      - dbus-gsd-housekeeping
-      - dbus-gsd-keyboard
-      - dbus-gsd-mediakeys
-      - dbus-gsd-power
-      - dbus-gsd-printnotifications
-      - dbus-gsd-rfkill
-      - dbus-gsd-screensaverproxy
-      - dbus-gsd-sharing
-      - dbus-gsd-smartcard
-      - dbus-gsd-sound
-      - dbus-gsd-usbprotection
-      - dbus-gsd-wacom
-      - dbus-gsd-wwan
-      - dbus-gsd-xsettings
       - dbus-gnome-nautilus
-      - dbus-gnome-shell
-      - dbus-gnome-shell-audio
-      - dbus-gnome-shell-introspect
-      - dbus-gnome-shell-portal
-      - dbus-gnome-shell-screencast
-      - dbus-gnome-shell-screenshot
-      - dbus-gnome-shell-wacom
       - dbus-gnome-settings
       - dbus-gnome-terminal
       - dbus-gnome-extensions
-      - dbus-gnome-shell-extensions
       - dbus-gtk-mountoperationhandler
       - dbus-gtk-notifications
       - dbus-gnome-notifications
       - dbus-gnome-calendar-server
       - dbus-gnome-hotplug-sniffer
-      - dbus-gtk-settings
       - dbus-kde-statusnotifier
       - dbus-desktop-icons
       - dbus-desktop-icons-extension
@@ -746,24 +707,11 @@ lint:
     - classic
 
 parts:
-  snapbuildtools:
-    source: https://github.com/sergio-costas/snap-build-tools.git
-    source-branch: manage-dangling-symlinks
-    source-depth: 1
-    plugin: nil
-    build-packages:
-      - python3-yaml
-    override-pull: |
-      craftctl default
-      $CRAFT_PART_SRC/install
-
   scripts:
-    after: [snapbuildtools]
     plugin: dump
     source: ./scripts
 
   ubuntu-desktop-session:
-    after: [snapbuildtools]
     plugin: nil
     build-packages:
       - git
@@ -772,7 +720,6 @@ parts:
       craftctl set version=$(date +%Y%m%d)+git$(git rev-parse --short HEAD)
 
   packages:
-    after: [snapbuildtools]
     plugin: nil
     build-packages:
       - libglib2.0-bin

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -724,6 +724,7 @@ parts:
     build-packages:
       - libglib2.0-bin
       - gtk-update-icon-cache
+      - python3-yaml
     stage-packages:
       - alsa-ucm-conf
       - at-spi2-core

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,12 +6,16 @@ description: |
 
 grade: stable
 confinement: strict
-base: core24-desktop
-build-base: core24
+base: core24
 platforms:
   all:
     build-on: amd64
-    build-for: all
+    build-for: amd64
+
+package-repositories:
+ - type: apt
+   ppa: desktop-snappers/core-desktop
+   priority: always
 
 environment:
   HOME: $SNAP_REAL_HOME
@@ -19,21 +23,234 @@ environment:
   XDG_CONFIG_HOME: $SNAP_USER_COMMON/.config
   XDG_DATA_HOME: $SNAP_USER_COMMON/.local/share
   XDG_STATE_HOME: $SNAP_USER_COMMON/.local/state
+  XDG_SESSION_TYPE: wayland
+  XDG_CURRENT_DESKTOP: ubuntu:GNOME
+  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio:$SNAP/usr/lib/gnome-settings-daemon-46:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libunity:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-3.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30
+  GSETTINGS_SCHEMA_DIR: $SNAP/usr/share/glib-2.0/schemas${GSETTINGS_SCHEMA_DIR:+:$GSETTINGS_SCHEMA_DIR}
+  GI_TYPELIB_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$SNAP/usr/lib/gnome-shell:$SNAP/usr/lib/gnome-shell/girepository-1.0:$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/mutter-14${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}
+  XDG_DATA_DIRS: /usr/share/gnome:/usr/share:$SNAP/usr/share:$SNAP/data-dir:/var/lib/snapd/desktop
+  PATH: ${PATH:+$PATH:}/bin:/usr/bin:$SNAP/usr/bin
+  SPA_PLUGIN_DIR: $SNAP/usr/lib/x86_64-linux-gnu/spa-0.2
+  PIPEWIRE_MODULE_DIR: $SNAP/usr/lib/x86_64-linux-gnu/pipewire-0.3
+  PIPEWIRE_CONFIG_DIR: $SNAP/usr/share/pipewire
+  LIBINPUT_QUIRKS_DIR: $SNAP/usr/share/libinput
+  PYTHONPATH: ${PYTHONPATH:+$PYTHONPATH:}/usr/lib/python3.12:/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3/dist-packages
+
+
+layout:
+  /usr/share/gnome-shell:
+    symlink: $SNAP/usr/share/gnome-shell
+  /usr/share/glvnd:
+    symlink: $SNAP/usr/share/glvnd
+  /usr/share/X11:
+    symlink: $SNAP/usr/share/X11
+  /usr/share/xml/iso-codes:
+    symlink: $SNAP/usr/share/xml/iso-codes
+  /usr/share/fonts:
+    bind: $SNAP/usr/share/fonts
+  /usr/share/fontconfig:
+    bind: $SNAP/usr/share/fontconfig
+  /usr/share/themes:
+    symlink: $SNAP/usr/share/themes
+  /usr/share/icons:
+    bind: $SNAP/usr/share/icons
+  /usr/share/mime:
+    symlink: $SNAP/usr/share/mime
+  /usr/share/tracker3:
+    symlink: $SNAP/usr/share/tracker3
+  /usr/share/tracker3-miners:
+    symlink: $SNAP/usr/share/tracker3-miners
+  /usr/share/libwacom:
+    symlink: $SNAP/usr/share/libwacom
+  /usr/share/language-tools:
+    symlink: $SNAP/usr/share/language-tools
+  /usr/share/nautilus:
+    symlink: $SNAP/usr/share/nautilus
+  /usr/share/gtk-3.0:
+    symlink: $SNAP/usr/share/gtk-3.0
+  /usr/share/gtk-4.0:
+    symlink: $SNAP/usr/share/gtk-4.0
+  /usr/share/defaults:
+    symlink: $SNAP/usr/share/defaults
+  /usr/share/xdg-desktop-portal:
+    symlink: $SNAP/usr/share/xdg-desktop-portal
+  /usr/share/backgrounds:
+    symlink: $SNAP/usr/share/backgrounds
+  /usr/share/pixmaps:
+    bind: $SNAP/usr/share/pixmaps
+  /usr/share/gnome-background-properties:
+    symlink: $SNAP/usr/share/gnome-background-properties
+  /usr/share/gnome-control-center:
+    symlink: $SNAP/usr/share/gnome-control-center
+  /usr/share/dbus-1/interfaces:
+    bind: $SNAP/usr/share/dbus-1/interfaces
+
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcanberra-0.30
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgweather-4
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0:
+    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/samba:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/samba
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-miners-3.0
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-3.0:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/tracker-3.0
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gnome-terminal:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gnome-terminal
+
+  /usr/libexec:
+    bind: $SNAP/usr/libexec
+
+  /etc/fonts:
+    bind: $SNAP/etc/fonts
+  /etc/gnome:
+    bind: $SNAP/etc/gnome
+  /etc/mime.types:
+    bind-file: $SNAP/etc/mime.types
+  /etc/profile.d/gnome-session_gnomerc.sh:
+    bind-file: $SNAP/etc/profile.d/gnome-session_gnomerc.sh
+  /etc/xdg:
+    bind: $SNAP/etc/xdg
+  /etc/profile.d/xdg-dirs-desktop-session.sh:
+    bind-file: $SNAP/etc/profile.d/xdg-dirs-desktop-session.sh
+  /etc/glvnd:
+    bind: $SNAP/etc/glvnd
+  /etc/gtk-3.0:
+    bind: $SNAP/etc/gtk-3.0
+  /etc/X11:
+    bind: $SNAP/etc/X11
+  /etc/pulse:
+    bind: $SNAP/etc/pulse
+
+  /usr/bin/Xwayland:
+    symlink: $SNAP/usr/bin/Xwayland
+  /usr/bin/X11:
+    symlink: $SNAP/usr/bin/X11
+  /usr/bin/xkbcomp:
+    symlink: $SNAP/usr/bin/xkbcomp
+  /usr/bin/xdg-user-dir:
+    symlink: $SNAP/usr/bin/xdg-user-dir
+  /usr/bin/xdg-user-dirs-update:
+    symlink: $SNAP/usr/bin/xdg-user-dirs-update
+  /usr/bin/gnome-session-quit:
+    bind-file: $SNAP/usr/bin/gnome-session-quit
+  /usr/bin/gnome-terminal.real:
+    symlink: $SNAP/usr/bin/gnome-terminal.real
 
 apps:
   ubuntu-desktop-session:
     command: run-session.sh
-    slots:
+    slots: &slotlist
       - wayland
       - x11
-#      - dbus-gnome-mutter-service-channel
-    plugs:
-      - account-control
+      - desktop
+      - dbus-canonical-unity
+      - dbus-freedesktop-impl-portal-gnome
+      # - dbus-freedesktop-impl-portal-gtk:
+      - dbus-freedesktop-screensaver
+      - dbus-freedesktop-secrets
+      - dbus-gnome-cc
+      - dbus-gnome-cc-search
+      - dbus-gnome-keyring
+      - dbus-gnome-keyring-sysprompter
+      - dbus-gnome-magnifier
+      - dbus-gnome-mutter-displayconfig
+      - dbus-gnome-mutter-idlemonitor
+      - dbus-gnome-mutter-input-capturer
+      - dbus-gnome-mutter-input-mapping
+      - dbus-gnome-mutter-remotedesktop
+      - dbus-gnome-mutter-screencast
+      - dbus-gnome-mutter-service-channel
+      - dbus-gnome-mutter-x11
+      - dbus-gnome-panel
+      - dbus-gnome-screensaver
+      - dbus-gnome-sessionmanager
+      - dbus-gsd
+      - dbus-gsd-a11ysettings
+      - dbus-gsd-color
+      - dbus-gsd-datetime
+      - dbus-gsd-housekeeping
+      - dbus-gsd-keyboard
+      - dbus-gsd-mediakeys
+      - dbus-gsd-power
+      - dbus-gsd-printnotifications
+      - dbus-gsd-rfkill
+      - dbus-gsd-screensaverproxy
+      - dbus-gsd-sharing
+      - dbus-gsd-smartcard
+      - dbus-gsd-sound
+      - dbus-gsd-usbprotection
+      - dbus-gsd-wacom
+      - dbus-gsd-wwan
+      - dbus-gsd-xsettings
+      - dbus-gnome-nautilus
+      - dbus-gnome-shell
+      - dbus-gnome-shell-audio
+      - dbus-gnome-shell-introspect
+      - dbus-gnome-shell-portal
+      - dbus-gnome-shell-screencast
+      - dbus-gnome-shell-screenshot
+      - dbus-gnome-shell-wacom
+      - dbus-gnome-settings
+      - dbus-gnome-terminal
+      - dbus-gnome-extensions
+      - dbus-gnome-shell-extensions
+      - dbus-gtk-mountoperationhandler
+      - dbus-gtk-notifications
+      - dbus-gnome-notifications
+      - dbus-gnome-calendar-server
+      - dbus-gnome-hotplug-sniffer
+      - dbus-gtk-settings
+      - dbus-kde-statusnotifier
+      - dbus-desktop-icons
+      - dbus-desktop-icons-extension
+      - dbus-portal
+      - dbus-ibus
+      - dbus-ibus-gtk3
+      - dbus-ibus-portal
+      - dbus-colord
+
+    plugs: &pluglist
+      - account-daemon
+      - audio-playback
+      - audio-record
+      - avahi-control
+      - bluetooth-control
+      - bluez
+      - cups-control
+      - desktop-launch
+      - dot-hidden
+      - dot-local-share-nautilus
+      - hardware-observe
+      - hostname-control
+      - home
       - locale-control
+      - login-session-observe
+      - login-session-control
+      - mount-observe
+      - network-bind
+      - network-control
+      - network-observe
+      - network-manager
+      - opengl
+      - pipewire
+      - polkit-agent
+      - process-control
+      - shell-config-files
+      - shell-session-locale-files
+      - shutdown
+      - ssh-keys
+      - system-observe
       - time-control
       - timeserver-control
       - timezone-control
-      - shell-session-locale-files
+      - upower-observe
 
   gnome-terminal-server:
     command: run.sh /usr/libexec/gnome-terminal-server
@@ -41,73 +258,188 @@ apps:
     daemon-scope: user
     activates-on:
       - dbus-gnome-terminal
+    restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
 
   screencast-service:
-    command: run.sh /usr/bin/gjs -m /usr/share/gnome-shell/org.gnome.Shell.Screencast
+    command: run.sh $SNAP/usr/bin/gjs -m /usr/share/gnome-shell/org.gnome.Shell.Screencast
     daemon: dbus
     daemon-scope: user
     activates-on:
       - dbus-gnome-shell-screencast
+    restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
+
+  extensions-service:
+    command: run.sh $SNAP/usr/bin/gnome-extensions-app --gapplication-service
+    daemon: dbus
+    daemon-scope: user
+    activates-on:
+      - dbus-gnome-extensions
+    restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
+
+  extensions-gnome-service:
+    command: run.sh $SNAP/usr/bin/gjs -m /usr/share/gnome-shell/org.gnome.Shell.Extensions
+    daemon: dbus
+    daemon-scope: user
+    activates-on:
+      - dbus-gnome-shell-extensions
+    restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
+
+  notifications-service:
+    command: run.sh $SNAP/usr/bin/gjs -m /usr/share/gnome-shell/org.gnome.Shell.Notifications
+    daemon: dbus
+    daemon-scope: user
+    activates-on:
+      - dbus-gnome-notifications
+    restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
+
+  screensaver-service:
+    command: run.sh $SNAP/usr/bin/gjs -m $SNAP/usr/share/gnome-shell/org.gnome.ScreenSaver
+    daemon: dbus
+    daemon-scope: user
+    activates-on:
+      - dbus-gnome-screensaver
+    restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
+
+  calendar-service:
+    command: run.sh $SNAP/usr/libexec/gnome-shell-calendar-server
+    daemon: dbus
+    daemon-scope: user
+    activates-on:
+      - dbus-gnome-calendar-server
+    restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
+
+  hotplug-service:
+    command: run.sh $SNAP/usr/libexec/gnome-shell-hotplug-sniffer
+    daemon: dbus
+    daemon-scope: user
+    activates-on:
+      - dbus-gnome-hotplug-sniffer
+    restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
+
 
   nautilus-service:
-    command: run.sh /usr/bin/nautilus --gapplication-service
+    command: run.sh $SNAP/usr/bin/nautilus --gapplication-service
     daemon: dbus
     daemon-scope: user
     activates-on:
       - dbus-gnome-nautilus
+    restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
 
   xdg-desktop-portal-gnome:
-    command: run.sh /usr/libexec/xdg-desktop-portal-gnome
+    command: run.sh $SNAP/usr/libexec/xdg-desktop-portal-gnome
     daemon: dbus
     daemon-scope: user
     activates-on:
       - dbus-freedesktop-impl-portal-gnome
     restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
+
+  org-freedesktop-impl-portal-secret:
+    command: run.sh $SNAP/launch-secrets.sh
+    daemon: dbus
+    daemon-scope: user
+    activates-on:
+      - dbus-freedesktop-impl-portal-secret
+    restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
 
   #xdg-desktop-portal-gtk:
-  #  command: run.sh /usr/libexec/xdg-desktop-portal-gtk
+  #  command: run.sh $SNAP/usr/libexec/xdg-desktop-portal-gtk
   #  daemon: dbus
   #  daemon-scope: user
   #  activates-on:
   #    - dbus-freedesktop-impl-portal-gtk
   #  restart-delay: 1s
+  #  plugs: *pluglist
+  #  slots: *slotlist
 
   ibus-service:
-    command: run.sh /usr/bin/ibus-daemon --panel disable
+    command: run.sh $SNAP/usr/bin/ibus-daemon --panel disable
     daemon: dbus
     daemon-scope: user
     activates-on:
       - dbus-ibus
+    restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
 
   ibus-gtk3-service:
-    command: run.sh /usr/libexec/ibus-extension-gtk3
+    command: run.sh $SNAP/usr/libexec/ibus-extension-gtk3
     daemon: dbus
     daemon-scope: user
     activates-on:
       - dbus-ibus-gtk3
+    restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
 
   ibus-portal-service:
-    command: run.sh /usr/libexec/ibus-portal
+    command: run.sh $SNAP/usr/libexec/ibus-portal
     daemon: dbus
     daemon-scope: user
     activates-on:
       - dbus-ibus-portal
+    restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
 
   colord:
-    command: run.sh /usr/libexec/colord-session
+    command: run.sh $SNAP/usr/libexec/colord-session
     daemon: dbus
     daemon-scope: user
     activates-on:
       - dbus-colord
+    restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
+
+  gnome-settings:
+    command: run.sh $SNAP/usr/bin/gnome-control-center
+    daemon: dbus
+    daemon-scope: user
+    activates-on:
+      - dbus-gnome-settings
+    restart-delay: 1s
+    plugs: *pluglist
+    slots: *slotlist
+
+  # gnome-settings-color:
+  #   command: run.sh $SNAP/usr/libexec/gsd-color
+  #   daemon: dbus
+  #   daemon-scope: user
+  #   restart-delay: 1s
+  #   plugs: *pluglist
+  #   slots: *slotlist
+
+  # gnome-settings-usb-protection:
+  #   command: run.sh $SNAP/usr/libexec/gsd-usd-protection
+  #   daemon: dbus
+  #   daemon-scope: user
+  #   restart-delay: 1s
+  #   plugs: *pluglist
+  #   slots: *slotlist
 
 plugs:
-  avahi-control: null
-  audio-playback: null
-  audio-record: null
-  bluez: null
-  bluetooth-control: null
-  cups-control: null
-  desktop-launch: null
   dot-local-share-nautilus:
     interface: personal-files
     write:
@@ -116,23 +448,6 @@ plugs:
     interface: personal-files
     write:
       - $HOME/.hidden
-  hardware-observe: null
-  hostname-control: null
-  home: null
-  login-session-observe: null
-  login-session-control: null
-  mount-observe: null
-  network-bind: null
-  network-control: null
-  network-observe: null
-  network-manager: null
-  opengl: null
-  #pipewire: null
-  polkit-agent: null
-  process-control: null
-  shutdown: null
-  ssh-keys: null
-  system-observe: null
   shell-session-locale-files:
     interface: personal-files
     write:
@@ -141,21 +456,24 @@ plugs:
   shell-config-files:
     interface: system-files
     read:
-      - /etc/fonts
-      - /etc/glvnd
-      - /etc/gnome/defaults.list
-      - /etc/gtk-3.0
-      - /etc/pulse
       - /etc/shells
-      - /etc/xdg/autostart
       - /run/udev/tags/seat
       - /etc/default/im-config
-      - /etc/X11/xinit/xinputrc
       - /etc/default/locale
-  upower-observe: null
+  gtk-3-themes:
+    interface: content
+    target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes
 
 slots:
-  desktop: null
   dbus-canonical-unity:
     interface: dbus
     bus: session
@@ -164,10 +482,14 @@ slots:
     interface: dbus
     bus: session
     name: org.freedesktop.impl.portal.desktop.gnome
-  dbus-freedesktop-impl-portal-gtk:
+  # dbus-freedesktop-impl-portal-gtk:
+  #   interface: dbus
+  #   bus: session
+  #   name: org.freedesktop.impl.portal.desktop.gtk
+  dbus-freedesktop-impl-portal-secret:
     interface: dbus
     bus: session
-    name: org.freedesktop.impl.portal.desktop.gtk
+    name: org.freedesktop.impl.portal.Secret
   dbus-freedesktop-screensaver:
     interface: dbus
     bus: session
@@ -204,6 +526,14 @@ slots:
     interface: dbus
     bus: session
     name: org.gnome.Mutter.IdleMonitor
+  dbus-gnome-mutter-input-capturer:
+    interface: dbus
+    bus: session
+    name: org.gnome.Mutter.InputCapture
+  dbus-gnome-mutter-input-mapping:
+    interface: dbus
+    bus: session
+    name: org.gnome.Mutter.InputMapping
   dbus-gnome-mutter-remotedesktop:
     interface: dbus
     bus: session
@@ -212,10 +542,15 @@ slots:
     interface: dbus
     bus: session
     name: org.gnome.Mutter.ScreenCast
-  #dbus-gnome-mutter-service-channel:
-  #  interface: dbus
-  #  bus: session
-  #  name: org.gnome.Mutter.ServiceChannel
+  dbus-gnome-mutter-service-channel:
+    interface: dbus
+    bus: session
+    name: org.gnome.Mutter.ServiceChannel
+  dbus-gnome-mutter-x11:
+    interface: dbus
+    bus: session
+    name: org.gnome.Mutter.X11
+
   dbus-gnome-panel:
     interface: dbus
     bus: session
@@ -340,6 +675,14 @@ slots:
     interface: dbus
     bus: session
     name: org.gnome.Terminal
+  dbus-gnome-extensions:
+    interface: dbus
+    bus: session
+    name: org.gnome.Extensions
+  dbus-gnome-shell-extensions:
+    interface: dbus
+    bus: session
+    name: org.gnome.Shell.Extensions
   dbus-gtk-mountoperationhandler:
     interface: dbus
     bus: session
@@ -348,6 +691,18 @@ slots:
     interface: dbus
     bus: session
     name: org.gtk.Notifications
+  dbus-gnome-notifications:
+    interface: dbus
+    bus: session
+    name: org.gnome.Shell.Notifications
+  dbus-gnome-calendar-server:
+    interface: dbus
+    bus: session
+    name: org.gnome.Shell.CalendarServer
+  dbus-gnome-hotplug-sniffer:
+    interface: dbus
+    bus: session
+    name: org.gnome.Shell.HotplugSniffer
   dbus-gtk-settings:
     interface: dbus
     bus: session
@@ -368,6 +723,7 @@ slots:
     interface: dbus
     name: org.freedesktop.impl.portal.PermissionStore
     bus: session
+
   dbus-ibus:
     interface: dbus
     name: org.freedesktop.IBus
@@ -385,14 +741,158 @@ slots:
     name: org.freedesktop.ColorHelper
     bus: session
 
+lint:
+  ignore:
+    - classic
+
 parts:
+  snapbuildtools:
+    source: https://github.com/sergio-costas/snap-build-tools.git
+    source-depth: 1
+    plugin: nil
+    build-packages:
+      - python3-yaml
+    override-pull: |
+      craftctl default
+      $CRAFT_PART_SRC/install
+
   scripts:
+    after: [snapbuildtools]
     plugin: dump
     source: ./scripts
+
   ubuntu-desktop-session:
+    after: [snapbuildtools]
     plugin: nil
     build-packages:
       - git
     override-build: |
       cd $CRAFT_PROJECT_DIR
       craftctl set version=$(date +%Y%m%d)+git$(git rev-parse --short HEAD)
+
+  packages:
+    after: [snapbuildtools]
+    plugin: nil
+    build-packages:
+      - libglib2.0-bin
+      - gtk-update-icon-cache
+    stage-packages:
+      - alsa-ucm-conf
+      - at-spi2-core
+      - fonts-ubuntu
+      - gir1.2-clutter-1.0
+      - gir1.2-dbusmenu-glib-0.4
+      - gir1.2-gsound-1.0
+      - gir1.2-glib-2.0-dev
+      - gkbd-capplet
+      - gnome-control-center
+      - gnome-keyring
+      - gnome-menus
+      - gnome-settings-daemon
+      - gnome-shell
+      - gnome-shell-common
+      - gnome-shell-extension-appindicator
+      - gnome-shell-extension-desktop-icons-ng
+      - gnome-shell-extension-prefs
+      - gnome-shell-extension-ubuntu-dock
+      - gnome-shell-extension-ubuntu-tiling-assistant
+      - gnome-terminal
+      - gsound-tools
+      - ibus
+      - im-config
+      - inotify-tools
+      - iso-codes
+      - language-selector-common
+      - language-selector-gnome
+      - libcanberra-pulse
+      - libfreetype6
+      - libgdk-pixbuf-2.0-0
+      - libgjs0g
+      - libgl1-mesa-dri
+      - libglib2.0-0t64
+      - libglu1-mesa
+      - libglut3.12
+      - libgsound0
+      - libpam-gnome-keyring
+      - libsnapd-glib-2-1
+      - libsysmetrics1
+      - locales-all
+      - locales
+      - media-types
+      - python3-gi
+      - polkitd
+      - pulseaudio-utils
+      - ubuntu-session
+      - ubuntu-settings
+      - xdg-desktop-portal
+      - xdg-desktop-portal-gnome
+      - xdg-user-dirs-gtk
+      - xdg-user-dirs
+      - xkb-data
+      - xwayland
+      - yaru-theme-gtk
+      - yaru-theme-gnome-shell
+      - yaru-theme-icon
+    stage:
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/alsa-lib
+    build-environment:
+      - LD_LIBRARY_PATH: /snap/core24/current/lib:/snap/core24/current/usr/lib:/snap/core24/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$CRAFT_PART_INSTALL/usr/lib:$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+
+    build-snaps:
+      - core24
+      - gtk-common-themes
+
+    override-build: |
+      # remove duplicated files
+      $CRAFT_PROJECT_DIR/snapbuildtools/remove_common.py -e usr/share/themes/\* usr/share/icons/\*/cursors\* usr/share/icons/\*/cursor.theme usr/libexec/\* usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0/gio\*
+
+      # recreate icons cache
+      for ICONPATH in $CRAFT_PART_INSTALL/usr/share/icons/*; do
+        if [ -f ${ICONPATH}/index.theme ]; then
+          gtk-update-icon-cache -f $ICONPATH
+        fi
+      done
+
+      # compile schemas
+      glib-compile-schemas $CRAFT_PART_INSTALL/usr/share/glib-2.0/schemas
+
+      # update pixbuf-loaders cache
+      export CACHE=$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders.cache
+      $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders/* > $CACHE
+      sed -i "s@$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@g" $CACHE
+
+      # update MIME types
+      $CRAFT_PART_INSTALL/usr/bin/update-mime-database $CRAFT_PART_INSTALL/usr/share/mime
+
+      # point to the right path
+      sed -i 's@exec /usr/libexec@exec $SNAP/usr/libexec@g' $CRAFT_PART_INSTALL/usr/bin/gnome-session
+      for FILENAME in $CRAFT_PART_INSTALL/usr/share/applications/*.desktop; do
+        sed -i "s@Exec=/usr@Exec=/snap/ubuntu-desktop-session/current/usr@g" $FILENAME
+      done
+
+      # Force gsd-xsettings to use the regular DISPLAY connection. If it
+      # tries to connect to :1, gnome-shell will not auto-start Xwayland.
+      mv $CRAFT_PART_INSTALL/usr/libexec/gsd-xsettings $CRAFT_PART_INSTALL/usr/libexec/gsd-xsettings.real
+      cat <<\EOF > $CRAFT_PART_INSTALL/usr/libexec/gsd-xsettings
+      #!/bin/sh
+      export GNOME_SETUP_DISPLAY="$DISPLAY"
+      exec /usr/libexec/gsd-xsettings.real "$@"
+      EOF
+      chmod a+x $CRAFT_PART_INSTALL/usr/libexec/gsd-xsettings
+
+      craftctl default
+
+    override-prime: |
+      craftctl default
+      rm -f ${CRAFT_PRIME}/usr/bin/pipewire*
+      rm -f ${CRAFT_PRIME}/usr/bin/pw-*
+
+      # Ensure that they point to the modules at the snap
+      ${CRAFT_PROJECT_DIR}/fix-gnome-modules.py ${CRAFT_PRIME}/usr/share/gnome-shell/org.gnome.Shell.Screencast
+      ${CRAFT_PROJECT_DIR}/fix-gnome-modules.py ${CRAFT_PRIME}/usr/share/gnome-shell/org.gnome.Extensions
+      ${CRAFT_PROJECT_DIR}/fix-gnome-modules.py ${CRAFT_PRIME}/usr/share/gnome-shell/org.gnome.ScreenSaver
+      ${CRAFT_PROJECT_DIR}/fix-gnome-modules.py ${CRAFT_PRIME}/usr/share/gnome-shell/org.gnome.Shell.Extensions
+      ${CRAFT_PROJECT_DIR}/fix-gnome-modules.py ${CRAFT_PRIME}/usr/share/gnome-shell/org.gnome.Shell.Notifications
+      ${CRAFT_PROJECT_DIR}/fix-gnome-modules.py ${CRAFT_PRIME}/etc/xdg/autostart/gnome-keyring-pkcs11.desktop
+      ${CRAFT_PROJECT_DIR}/fix-gnome-modules.py ${CRAFT_PRIME}/etc/xdg/autostart/gnome-keyring-secrets.desktop
+      ${CRAFT_PROJECT_DIR}/fix-gnome-modules.py ${CRAFT_PRIME}/etc/xdg/autostart/gnome-keyring-ssh.desktop

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -217,7 +217,7 @@ apps:
       - dbus-colord
 
     plugs: &pluglist
-      - account-daemon
+      - account-control
       - audio-playback
       - audio-record
       - avahi-control
@@ -748,6 +748,7 @@ lint:
 parts:
   snapbuildtools:
     source: https://github.com/sergio-costas/snap-build-tools.git
+    source-branch: manage-dangling-symlinks
     source-depth: 1
     plugin: nil
     build-packages:

--- a/snapbuildtools/remove_common.py
+++ b/snapbuildtools/remove_common.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+
+""" Removes files that are already in base snaps or have been generated
+    in a previous part. Useful to remove files added by stage-packages
+    due to dependencies, but that aren't required because they are
+    already available in core22, gnome-42-2204 or gtk-common-themes,
+    or have already been built by a previous part. """
+
+import os
+import glob
+import argparse
+import fnmatch
+try:
+    import yaml
+except:
+    print("YAML module not found. Please, add 'python3-yaml' to the 'build-packages' list.")
+    pass
+
+parser = argparse.ArgumentParser(prog="remove_common", description="An utility to remove from snaps files that are already available in extensions")
+parser.add_argument('extension', nargs='*', default=[])
+parser.add_argument('-e', '--exclude', nargs='+', help="A list of files and directories to exclude from checking")
+parser.add_argument('-m', '--map', nargs='+', default=[], help="A list of snap_name:path pairs")
+parser.add_argument('-v', '--verbose', action='store_true', default=False, help="Show extra info")
+parser.add_argument('-q', '--quiet', action='store_true', default=False, help="Don't show any message")
+parser.add_argument('--snap-prefix', default=None, help="Set snaps folder (only for debugging/testing)")
+args = parser.parse_args()
+
+class Configuration:
+    """ Contains all the desired configuration for removing common files """
+    def __init__(self, *,
+                 verbose = False,
+                 quiet = False,
+                 mappings = [],
+                 excludes = None,
+                 extensions = [],
+                 snap_prefix = None):
+        """ Initialized the class
+
+        Parameters
+        ----------
+        verbose : bool, optional
+            If the program must be more verbose and show extra messages, by default False
+        quiet : bool, optional
+            If the program must be quiet and show no messages, by default False
+        mappings : list, optional
+            A list of strings with the extension mapping, in the form
+            'extension_snap_name:mapping_path_prefix'. This is useful when the contents of an
+            extension aren't mapped directly to the corresponding relative path
+            in our snap. An example is gtk-common-themes, whose their paths must
+            be prefixed by 'usr/' to match the corresponding path in our snap. By default []
+        excludes : list, optional
+            A list of strings with rules to exclude files. These rules can contain
+            wildcard characters like in a shell command line; thus * and ?. By default None
+        extensions : list, optional
+            _description_, by default []
+        """
+        # specific case for themed icons
+        self._global_excludes = ['usr/share/icons/*/index.theme']
+        self._global_maps = ['gtk-common-themes:usr']
+
+        if ( excludes is not None) and len(excludes) != 0:
+            self._global_excludes += excludes
+
+        # this is useful for tests, to change where the folders are
+        self._snap_prefix = '/snap' if snap_prefix is None else snap_prefix
+        self._custom_extensions = []
+        self.verbose = verbose
+        self.quiet = quiet
+        self._mapping_list = mappings
+        self._extensions_list = extensions
+        self._extensions_paths = None
+        self._yaml = None
+
+        if verbose:
+            print(f"Removing duplicates already in {extensions}")
+
+
+    def add_extension_path(self, extension, files_path, path_mapping = None):
+        """ Adds the path of an extension
+
+        Parameters
+        ----------
+        extension : string
+            The extension name, or None if it is the stage folder
+        files_path : string
+            The path where the data of the extension is stored
+        path_mapping : string or None, optional
+            The mapping path required to match the paths inside this
+            extension snap and the paths in our snap. By default None
+        """
+        if (files_path is None) or (files_path == ""):
+            return
+        self._custom_extensions.append((extension, files_path, path_mapping))
+
+
+    def add_exclude(self, exclude):
+        self._global_excludes.append(exclude)
+
+
+    @property
+    def exclude_list(self):
+        return self._global_excludes
+
+
+    @property
+    def extensions_paths(self):
+        extensions = self._get_extensions_list(self._extensions_list)
+        if len(extensions) == 0:
+            raise RuntimeError("Called remove_common.py without a list of snaps, and no 'build-snaps' entry in the snapcraft.yaml file.")
+        mappings = self._generate_mappings(self._global_maps, self._mapping_list)
+        extensions_paths = self._generate_extensions_paths(extensions, mappings)
+        return extensions_paths + self._custom_extensions
+
+
+    def _load_snapcraft_yaml(self):
+        """ Loads the snapcraft.yaml file in memory """
+
+        # Don't load it if it was already loaded
+        if self._yaml is not None:
+            return
+
+        if 'CRAFT_PROJECT_DIR' not in os.environ:
+            return
+
+        project_folder = os.environ['CRAFT_PROJECT_DIR']
+        snapcraft_file_path = os.path.join(project_folder, "snapcraft.yaml")
+        if not os.path.exists(snapcraft_file_path):
+            snapcraft_file_path = os.path.join(project_folder, "snap", "snapcraft.yaml")
+            if not os.path.exists(snapcraft_file_path):
+                return
+        with open(snapcraft_file_path, "r") as snapcraft_stream:
+            self._yaml = yaml.load(snapcraft_stream, Loader=yaml.Loader)
+
+
+    def _get_extensions_list(self, cmdline_extensions):
+        """Returns an array with the extensions for this project.
+
+        It returns either the list of extensions passed in the command line, or
+        the list of extensions extracted from the snapcraft.yaml file.
+
+        Parameters
+        ----------
+        cmdline_extensions : array of strings
+            an array with the list of extensions passed by the command line.
+            If no extensions were passed, it must be a zero-length array.
+
+        Returns
+        -------
+        array of strings
+            an array with the list of extensions desired. If no extensions are
+            defined, it will return a zero-length array.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the snapcraft.yaml file can't be found.
+        """
+
+        if len(cmdline_extensions) != 0:
+            return cmdline_extensions
+
+        self._load_snapcraft_yaml()
+        parts_data = self._yaml["parts"]
+        extensions = []
+        for part_name in parts_data:
+            part_data = parts_data[part_name]
+            if "build-snaps" not in part_data:
+                continue
+            for extension in part_data["build-snaps"]:
+                if extension not in extensions:
+                    extensions.append(extension)
+        return extensions
+
+
+    def _generate_mappings(self, predefined_mappings, cmdline_mappings = []):
+        """Parses the specific mappings for each snap
+
+        It receives both the predefined mappings and the mappings passed by
+        command line, and returns a dictionary with each snap and its corresponding
+        mapping path.
+
+        Parameters
+        ----------
+        predefined_mappings : array of strings
+            An array of strings, each one in the format snap_name:mapping. Used
+            for the "known mappings", like the one for gtk-common-themes.
+        cmdline_mappings : array of strings
+            An array of strings as received from argparse with the snap_name:mapping
+            pairs.
+
+        Returns
+        -------
+        dictionary
+            A dictionary where each key is a string with a snap name and the
+            value is another string with the mapping path for that snap, ended
+            in '/'.
+
+        Raises
+        ------
+        SyntaxError
+            If the format of any of the mapping strings is not valid
+        """
+
+        mappings = {}
+
+        for map in predefined_mappings + cmdline_mappings:
+            elements = map.split(":")
+            if len(elements) != 2:
+                raise SyntaxError("Error in mapping. It must be in the format snap_name:path", {'filename': 'remove_common.py', 'text': map, 'lineno': 0, 'offset': 0})
+            if elements[1] == '/':
+                raise SyntaxError("The mapping can't be '/'", {'filename': 'remove_common.py', 'text': map, 'lineno': 0, 'offset': 0})
+            while elements[1][0] == '/':
+                elements[1] = elements[1][1:]
+            if elements[1][-1] != '/':
+                elements[1] += '/'
+            mappings[elements[0]] = elements[1]
+
+        return mappings
+
+
+    def _generate_extensions_paths(self, extensions, mappings):
+        """Generates the list of extensions paths from the list of extensions
+
+        This list has the paths of each extension used, to know where to search
+        for duplicates. Also, it contains the corresponding map for each path.
+
+        Parameters
+        ----------
+        extensions : array of strings
+            An array of strings with the names of the extensions used in this snap.
+        mappings : dictionary
+            A dictionary where each key is a string with a snap name and the
+            value is another string with the mapping path for that snap, ended
+            in '/'.
+
+        Returns
+        -------
+        array of tuples
+            An array of tuples, where the first element of each tuple is a string
+            to the contents of each extension, and the second element is the mapping
+            for that path, or None if no mapping is needed.
+        """
+
+        folders = []
+        for snap in extensions:
+            path = os.path.join(self._snap_prefix, snap, "current")
+            map_path = mappings[snap] if snap in mappings else None
+            folders.append((snap, path, map_path))
+        return folders
+
+
+def check_if_exists(config, relative_file_path):
+    """Checks if an specific file does exist in any of the base paths.
+
+    Checks if the specified file at `relative_file_path` does exist in
+    any of the paths included in the `extensions_paths` array, taking into
+    account the mapping specified.
+
+    Mapping is paramount for some extension snaps like gtk-common-themes.
+    In this specific case, the snap contains the `share` folder directly
+    at its root folder, while any other snap would have it inside the
+    `usr` folder. Thus, for that extension snap, the map must be `usr`
+    to instruct this function to remove `usr` from the beginning of the
+    relative path when checking for a file inside gtk-common-themes.
+
+    Parameters
+    ----------
+    config : Configuration
+        This object must contain the current configuration data
+    relative_file_path : string
+        The file path to search in the folder list, relative to the
+        snap root.
+
+    Returns
+    -------
+    boolean
+        It returns True if the file does exist in, at least, one of the
+        specified snaps, and false if it doesn't exist in any of them.
+    """
+
+    # Checks if an specific file does exist in any of the base paths
+    for _, folder, map_path in config.extensions_paths:
+        if (map_path is not None) and relative_file_path.startswith(map_path):
+            relative_file_path2 = relative_file_path[len(map_path):]
+            if relative_file_path2[0] == '/':
+                relative_file_path2 = relative_file_path2[1:]
+        else:
+            relative_file_path2 = relative_file_path
+        check_path = os.path.join(folder, relative_file_path2)
+        if os.path.exists(check_path):
+            if config.verbose:
+                print(f"The path {relative_file_path} has been found inside {folder} with map {map_path}: {relative_file_path2}")
+            return True
+    return False
+
+def find_symlinks(snap_folder):
+    """"Find symlinks
+
+    Searches the snap being built for symlinks, and stores the original file.
+    This is needed to ensure that no dangling symlinks are left in the new
+    snap.
+
+    Parameters
+    ----------
+    snap_folder : string
+        The path of the folder where are the possible symlinks to duplicated files.
+
+    Returns
+    -------
+    dictionary string : array[string]
+        A dictionary where each key is a destination file, and the value is an array
+        with all the symlinks pointing to that file.
+    """
+
+    symlinks = {}
+    for full_symlink_path in glob.glob(os.path.join(snap_folder, "**/*"), recursive=True):
+        if not os.path.islink(full_symlink_path):
+            continue
+        destination = os.path.realpath(full_symlink_path)
+        if not os.path.isfile(destination):
+            continue
+        if destination not in symlinks:
+            symlinks[destination] = []
+        symlinks[destination].append(full_symlink_path)
+    return symlinks
+
+def _remove_duplicated_file(full_file_path, symlink_list):
+    """ Deletes a file that we know that is duplicated, and ensures that if a
+    symlink points to it, the symlink will be replaced with a copy of the file.
+    But if it is a symlink, it will be removed from the list of symlinks to
+    avoid re-creating it in case that the symlink is deleted after.
+
+    Parameters
+    ----------
+    full_file_path : string
+        The full path to the file/symlink to delete
+
+    symlink_list : dictionary string : [string]
+        A dictionary with full path to files as keys, and an array of all the
+        full paths of symlinks pointing to that file as the value.
+
+    Returns
+    -------
+    An integer with the number of bytes freed after deleting that file.
+    """
+
+    if full_file_path in symlink_list:
+        for link_path in symlink_list[full_file_path]:
+            if os.path.exists(link_path):
+                os.remove(link_path)
+                os.link(full_file_path, link_path)
+    duplicated_bytes = 0
+    real_path = os.path.realpath(full_file_path)
+    if os.path.exists(real_path):
+        file_data = os.stat(full_file_path)
+        if os.path.isfile(full_file_path) and (file_data.st_nlink == 1):
+            duplicated_bytes = file_data.st_size
+    os.remove(full_file_path)
+    return duplicated_bytes
+
+def main(*, snap_folder, config):
+    """Main function
+
+    Searches each file in 'snap_folder' inside each path in 'extensions_paths'
+    to check if it is already available there, deleting it in that case, unless
+    it matches any of the rules in 'exclude_list'.
+
+    The check is done based only on the relative path and file name relative to
+    'snap_folder', searching that inside each path in 'extensions_paths', although
+    taking into account the mapping.
+
+    Parameters
+    ----------
+    snap_folder : string
+        The path of the folder where the staged .deb have been uncompressed (usually
+        CRAFT_PART_INSTALL)
+    config : Configuration
+        A Configuration object with the desired configuration for extensions_paths
+        and exclude_list.
+    """
+
+    duplicated_bytes = 0
+    symlink_list = find_symlinks(snap_folder)
+
+    for full_file_path in glob.glob(os.path.join(snap_folder, "**/*"), recursive=True):
+        if not os.path.isfile(full_file_path) and not os.path.islink(full_file_path):
+            continue
+        relative_file_path = full_file_path[len(snap_folder):]
+        if relative_file_path[0] == '/':
+            relative_file_path = relative_file_path[1:]
+        do_exclude = False
+        for exclude in config.exclude_list:
+            if fnmatch.fnmatch(relative_file_path, exclude):
+                if config.verbose:
+                    print(f"Excluding {relative_file_path} with rule {exclude}")
+                do_exclude = True
+                break
+        if do_exclude:
+            continue
+        if check_if_exists(config, relative_file_path):
+            duplicated_bytes += _remove_duplicated_file(full_file_path, symlink_list)
+            if config.verbose:
+                print(f"Removing duplicated file {relative_file_path} {full_file_path}")
+    if not config.quiet:
+        print(f"Removed {duplicated_bytes} bytes in duplicated files")
+
+
+if __name__ == "__main__":
+    configuration = Configuration(verbose=args.verbose,
+                                  quiet=args.quiet,
+                                  mappings=args.map,
+                                  excludes=args.exclude,
+                                  extensions=args.extension,
+                                  snap_prefix=args.snap_prefix)
+    if "CRAFT_STAGE" in os.environ:
+        configuration.add_extension_path(None, os.environ["CRAFT_STAGE"], None)
+
+    # This is the folder where to check for duplicates that are already
+    # in other snaps, or in the stage because they were built in other
+    # parts.
+    snap_folder = os.environ["CRAFT_PART_INSTALL"]
+
+    main(snap_folder=snap_folder, config = configuration)


### PR DESCRIPTION
First `stand-alone` working version. This snap contains a fully working, stand-alone, Ubuntu Desktop Session, and also removes duplicated files from gtk-common-themes and core24, which reduces de size in about 50 MBytes. Duplicated libraries from gnome-46-2404 is a little more complex, due to several conflicts, so it will be delayed for a future version, although it could free another 50MBytes approximately.

It requires https://github.com/canonical/core-base-desktop/pull/76